### PR TITLE
Incorporate V3.0.2 changes

### DIFF
--- a/documentation/IDTA-01003-a/modules/ROOT/pages/Annex/IDTA-01003-a_HandlingConstraints.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/Annex/IDTA-01003-a_HandlingConstraints.adoc
@@ -14,8 +14,10 @@ Plattform Industrie 4.0; Anna Salari, Publik. Agentur für Kommunikation GmbH, d
 
 = Handling of Constraints
 
-Constraints are prefixed with *AASc-3a-* followed by a three-digit number. The "c" in "AASc-" was motivated by "Concept Description". The numbering of constraints is unique within namespace AASc-3a; a number of a constraint that was removed will not be used again.
+Constraints are prefixed with *AASc-3a-* followed by a three-digit number. The "c" in "AASc-" was motivated by "Concept Description". 
+The numbering of constraints is unique within namespace AASc-3a; a number of a constraint that was removed will not be used again.
 
+If a constraint is mentioning the ID of the Template, then the same constraints shall also be valid for deprecated data specification template IDs.
 
 ====
 Note: in the Annex listing the metamodel changes, constraints with prefix AASd-, AASs- or AASc- are also listed. These are metamodel, security or data specification constraints, and are now part of the split document parts.

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/IDTA-01003-a_ChangeLog.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/IDTA-01003-a_ChangeLog.adoc
@@ -69,14 +69,16 @@ Bugfixes:
 
 * all constraints corrected that mention data specification template ID: instead of complete version "3/0" only major version "3" 
 
++ added note in Annex “Handling of Constraints”: If a constraint is mentioning the id of the Template, then the same constraints shall also be valid for deprecated data specification template IDs
+
 * change numbering of constraints that do not yet had "-3a" in their name
 
 .New, Changed or Removed Constraints in V3.0.2
 [width="100%",cols="7%,12%,15%,66%",options="header",]
 |===
-h|nc h|V3.0.2 vs. V3.0.1 h|New, Update, Removed, Reformulated h|Comment
+h|nc h|V3.0.2 vs. V3.0.1 h|New, Update, Removed, Reformulated, Renamed h|Comment
 
-| | AASc-002 | Update a| renamed to AASc-3a-002
+| | AASc-002 | Renamed a| renamed to AASc-3a-002
 
 | | AASc-3a-003 | Update a| Now `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3`
 
@@ -102,9 +104,9 @@ AASc-3a-007: For a _ConceptDescription_ with _category_ QUALIFIER_TYPE using dat
 
 AASc-3a-008: For a _ConceptDescription_ using data specification template IEC61360 (`\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3`), _DataSpecificationIec61360/definition_ is mandatory and shall be defined at least in English. Exception: the concept description describes a value, i.e. _DataSpecificationIec61360/value_ is defined.
 
-| | AASc-009 | Update a| renamed to AASc-3a-009
+| | AASc-009 | Renamed a| renamed to AASc-3a-009
 
-| | AASc-010 | Update a| renamed to AASc-3a-010
+| | AASc-010 | Renamed a| renamed to AASc-3a-010
 
 
 | | AASc-3a-050 | Update a| Now `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3`

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/IDTA-01003-a_ChangeLog.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/IDTA-01003-a_ChangeLog.adoc
@@ -1,3 +1,13 @@
+////
+Copyright (c) 2023 Industrial Digital Twin Association
+
+This work is licensed under a [Creative Commons Attribution 4.0 International License](
+https://creativecommons.org/licenses/by/4.0/). 
+
+SPDX-License-Identifier: CC-BY-4.0
+
+////
+
 = Metamodel Changes
 
 == General
@@ -17,15 +27,20 @@ Each subclause consists of three parts:
 * new elements in metamodel w.r..t previous version,
 * new, changed, or removed Constraints w.r.t previous version.
 
-== Changes V3.1 vs. V3.0.1
+
+
+== Changes V3.1 vs. V3.0.2
 
 Major changes:
 
 * CHANGE ValueTypeIec61360: increase length from 2000 to 2048 (https://github.com/admin-shell-io/aas-specs/issues/306[#306 of IDTA-01001])
 
+////
 * increase version in metamodel semantic IDs to /3/1. Update all links to template ID in constraints
+////
 
 * Transfer from .docx to asciidoc 
+
 * Update Terms and Definitions to be compliant to IEC63278-1:2023 and other parts of specification
 
 Minor changes:
@@ -40,70 +55,127 @@ Minor changes:
 .Changes in Metamodel V3.1
 [width="100%",cols="7%,53%,40%",options="header",]
 |===
-|*nc* |*V3.1 vs. Part 1 V3.0.1* |*Comment*
+|*nc* |*V3.1 vs. V3.0.2* |*Comment*
 | |ValueTypeIec61360 | Change length of data type from 2000 to 2048
 |===
 
 
-.New, Changed or Removed Constraints in V3.1
+
+
+
+== Changes V3.0.2 vs. V3.0.1
+
+Bugfixes:
+
+* all constraints corrected that mention data specification template ID: instead of complete version "3/0" only major version "3" 
+
+* change numbering of constraints that do not yet had "-3a" in their name
+
+.New, Changed or Removed Constraints in V3.0.2
 [width="100%",cols="7%,12%,15%,66%",options="header",]
 |===
-h|nc h|V3.1 vs. V3.0.1 h|New, Update, Removed, Reformulated h|Comment
+h|nc h|V3.0.2 vs. V3.0.1 h|New, Update, Removed, Reformulated h|Comment
 
-| | AASc-3a-003 | Update a| Now \https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1
+| | AASc-002 | Update a| renamed to AASc-3a-002
 
-AASc-3a-003: For a _ConceptDescription_ referenced via _ValueList/valueId_ and using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1), _DataSpecificationIec61360/value_ shall be set.
+| | AASc-3a-003 | Update a| Now `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3`
 
-| | AASc-3a-004 | Update a| Now \https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1
+AASc-3a-003: For a _ConceptDescription_ referenced via _ValueList/valueId_ and using data specification template IEC61360 (`\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3`), _DataSpecificationIec61360/value_ shall be set.
 
-AASc-3a-004: For a _ConceptDescription_ with _category_ _PROPERTY_ or _VALUE_ using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1), _DataSpecificationIec61360/dataType_ is mandatory and shall be one of _DATE, STRING, STRING_TRANSLATABLE, INTEGER_MEASURE, INTEGER_COUNT, INTEGER_CURRENCY, REAL_MEASURE, REAL_COUNT, REAL_CURRENCY, BOOLEAN, RATIONAL, RATIONAL_MEASURE, TIME, TIMESTAMP_.
+| | AASc-3a-004 | Update a|  Now `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3`
 
-| | AASc-3a-005 | Update a| Now \https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1
+AASc-3a-004: For a _ConceptDescription_ with _category_ _PROPERTY_ or _VALUE_ using data specification template IEC61360 (`\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3`), _DataSpecificationIec61360/dataType_ is mandatory and shall be one of _DATE, STRING, STRING_TRANSLATABLE, INTEGER_MEASURE, INTEGER_COUNT, INTEGER_CURRENCY, REAL_MEASURE, REAL_COUNT, REAL_CURRENCY, BOOLEAN, RATIONAL, RATIONAL_MEASURE, TIME, TIMESTAMP_.
 
-AASc-3a-005: For a _ConceptDescription_ with _category_ REFERENCE using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1), _DataSpecificationIec61360/dataType_ shall be one of _STRING, IRI, IRDI_.
+| | AASc-3a-005 | Update a| Now `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3`
 
-| | AASc-3a-006 | Update a| Now \https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1
+AASc-3a-005: For a _ConceptDescription_ with _category_ REFERENCE using data specification template IEC61360 (`\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3`), _DataSpecificationIec61360/dataType_ shall be one of _STRING, IRI, IRDI_.
 
-AASc-3a-006: For a _ConceptDescription_ with _category_ DOCUMENT using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1), _DataSpecificationIec61360/dataType_ shall be one of _FILE, BLOB, HTML_.
+| | AASc-3a-006 | Update a| Now `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3`
 
-| | AASc-3a-007 | Update a| Now \https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1
+AASc-3a-006: For a _ConceptDescription_ with _category_ DOCUMENT using data specification template IEC61360 (`\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3`), _DataSpecificationIec61360/dataType_ shall be one of _FILE, BLOB, HTML_.
 
-AASc-3a-007: For a _ConceptDescription_ with _category_ QUALIFIER_TYPE using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1), _DataSpecificationIec61360/dataType_ is mandatory and shall be defined.
+| | AASc-3a-007 | Update a| Now `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3`
 
-| | AASc-3a-008 | Update a| Now \https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1
+AASc-3a-007: For a _ConceptDescription_ with _category_ QUALIFIER_TYPE using data specification template IEC61360 (`\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3`), _DataSpecificationIec61360/dataType_ is mandatory and shall be defined.
 
-AASc-3a-008: For a _ConceptDescription_ using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1), _DataSpecificationIec61360/definition_ is mandatory and shall be defined at least in English. Exception: the concept description describes a value, i.e. _DataSpecificationIec61360/value_ is defined.
+| | AASc-3a-008 | Update a| Now `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3`
 
-| | AASc-3a-050 | Update a| Now \https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1
+AASc-3a-008: For a _ConceptDescription_ using data specification template IEC61360 (`\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3`), _DataSpecificationIec61360/definition_ is mandatory and shall be defined at least in English. Exception: the concept description describes a value, i.e. _DataSpecificationIec61360/value_ is defined.
 
-AASc-3a-050: If the _DataSpecificationContent_ _DataSpecificationIec61360_ is used for an element, the value of _HasDataSpecification/dataSpecification_ shall contain the external reference to the IRI of the corresponding data specification template \https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1.
+| | AASc-009 | Update a| renamed to AASc-3a-009
+
+| | AASc-010 | Update a| renamed to AASc-3a-010
+
+
+| | AASc-3a-050 | Update a| Now `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3`
+
+AASc-3a-050: If the _DataSpecificationContent_ _DataSpecificationIec61360_ is used for an element, the value of _HasDataSpecification/dataSpecification_ shall contain the external reference to the IRI of the corresponding data specification template `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3`.
 |===
+
+
 
 
 == Changes V3.0.1 vs. V3.0
 
 Bugfixes:
 
-* also support deprecated template ID `\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/0` (https://github.com/admin-shell-io/aas-specs-iec61360/issues/4[#4])
-* removed sentence stating that the template ID is conformant to the rules for semantic IDs for data specifications as defined in Part 1 of the document series [AAS-Part1]: this is not the case but the ID will not be changed 
+* also support deprecated data specification template IDs  (https://github.com/admin-shell-io/aas-specs-iec61360/issues/4[#4], https://github.com/admin-shell-io/aas-specs-iec61360/issues/2[#2])
+
+** `\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/0` 
+** `\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0` 
+** `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0` 
+
+* For backward compatibility of future versions of this specification the ID of data specification template and value of attribute “id” of DataSpecification are now distinguished: Therefore  `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/0`  is also deprecated and `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3`  shall be used instead
+
+
+* corrected examples for qualifier of namespace IEC (min instead of Min for enumeration LevelType)
+
+* removed sentence stating that the template ID is conformant to the rules for semantic IDs for data specifications as defined in 
+Part 1 (IDTA-01001-3-0) of the document series: this is not the case but the ID will not be changed 
+
 * (Editorial) Constraint AASc-3a-050: external reference instead of globale reference 
+
 * (Editorial) Notes "Note: it is recommended to use a global
 reference." were updated to "Note: it is recommended to use an external
 reference." (https://github.com/admin-shell-io/aas-specs-iec61360/issues/5[#5])
-* (Editorial) Examples corrected for `IEC:DataSpecificationIec61360/levelType/Min` and `IEC:LevelType/Min` (min with small letter)
+
+
 
 .New, Changed or Removed Constraints in V3.0.1
 [width="100%",cols="7%,12%,15%,66%",options="header",]
 |===
-h|Nc h|V3.0.1 vs. V3.0 h|New, Update, Removed, Reformulated h|Comment
-| | AASc-3a-050 | Update a| External instead of global reference
+h|nc h|V3.0 vs. V3.0.1 h|New, Update, Removed, Reformulated h|Comment
 
-+++Constraint AASc-3a-050+++: If the _DataSpecificationContent_ _DataSpecificationIec61360_ is used for an element, the value of _HasDataSpecification/dataSpecification_ shall contain the global reference to the IRI of the corresponding data specification template \https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/0.
+| | AASc-3a-003 | Update a| Change http to https
 
-changed to 
+AASc-3a-003: For a _ConceptDescription_ referenced via _ValueList/valueId_ and using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/0), _DataSpecificationIec61360/value_ shall be set.
 
-+++Constraint AASc-3a-050+++: If the _DataSpecificationContent_ _DataSpecificationIec61360_ is used for an element, the value of _HasDataSpecification/dataSpecification_ shall contain the external reference to the IRI of the corresponding data specification template \https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/0.
+| | AASc-3a-004 | Update a| Change http to https
+
+AASc-3a-004: For a _ConceptDescription_ with _category_ _PROPERTY_ or _VALUE_ using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/0), _DataSpecificationIec61360/dataType_ is mandatory and shall be one of _DATE, STRING, STRING_TRANSLATABLE, INTEGER_MEASURE, INTEGER_COUNT, INTEGER_CURRENCY, REAL_MEASURE, REAL_COUNT, REAL_CURRENCY, BOOLEAN, RATIONAL, RATIONAL_MEASURE, TIME, TIMESTAMP_.
+
+| | AASc-3a-005 | Update a| Change http to https
+
+AASc-3a-005: For a _ConceptDescription_ with _category_ REFERENCE using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/0), _DataSpecificationIec61360/dataType_ shall be one of _STRING, IRI, IRDI_.
+
+| | AASc-3a-006 | Update a| Change http to https
+
+AASc-3a-006: For a _ConceptDescription_ with _category_ DOCUMENT using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/0), _DataSpecificationIec61360/dataType_ shall be one of _FILE, BLOB, HTML_.
+
+| | AASc-3a-007 | Update a| Change http to https
+
+AASc-3a-007: For a _ConceptDescription_ with _category_ QUALIFIER_TYPE using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/0), _DataSpecificationIec61360/dataType_ is mandatory and shall be defined.
+
+| | AASc-3a-008 | Update a| Change http to https
+
+AASc-3a-008: For a _ConceptDescription_ using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/0), _DataSpecificationIec61360/definition_ is mandatory and shall be defined at least in English. Exception: the concept description describes a value, i.e. _DataSpecificationIec61360/value_ is defined.
+
+| | AASc-3a-050 | Update a| Change http to https and External instead of global reference
+
+AASc-3a-050: If the _DataSpecificationContent_ _DataSpecificationIec61360_ is used for an element, the value of _HasDataSpecification/dataSpecification_ shall contain the external reference to the IRI of the corresponding data specification template \https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/0.
 |===
+
+
 
 == Changes V3.0 vs. Part 1 V2.0.1
 
@@ -184,15 +256,15 @@ Updated version of AASd-076, renamed to AASc-3a-002 because applicable to data s
 
 Constraint AASc-3a-002: DataSpecificationIec61360/preferredName shall be provided at least in English.
 
-|(x) |AASc-3a-003 |New |Constraint AASc-3a-003: For a _ConceptDescription_ referenced via _ValueList/valueId_ and using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/0), _DataSpecificationIec61360/value_ shall be set.
-|(x) |AASc-3a-004 |New |Constraint AASc-004: For a ConceptDescription with category PROPERTY or VALUE using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/0), DataSpecificationIec61360/dataType is mandatory and shall be defined.
-|(x) |AASc-3a-005 |New |Constraint AASc-005: For a ConceptDescription with category REFERENCE using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/0), DataSpecificationIec61360/dataType is STRING by default.
-|(x) |AASc-3a-006 |New |Constraint AASc-006: For a ConceptDescription with category DOCUMENT using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/0), DataSpecificationIec61360/dataType shall be one of the following values: STRING or URL.
-|(x) |AASc-3a-007 |New |Constraint AASc-007: For a ConceptDescription with category QUALIFIER_TYPE using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/0), DataSpecificationIec61360/dataType is mandatory and shall be defined.
-|(x) |AASc-3a-008 |New |Constraint AASc-3a-008: For a ConceptDescription using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/0), DataSpecificationIec61360/definition is mandatory and shall be defined at least in English. Exception: the concept description describes a value, i.e. DataSpecificationIec61360/value is defined.
-|(x) |AASc-3a-009 |New |Constraint AASc-009: If DataSpecificationIec61360/dataType is one of INTEGER_MEASURE, REAL_MEASURE, RATIONAL_MEASURE, INTEGER_CURRENCY, REAL_CURRENCY, then DataSpecificationIec61360/unit or DataSpecificationIec61360/unitId shall be defined.
-|(x) |AASc-3a-010 |New |Constraint AASc-010: If DataSpecificationIec61360/value is not empty, DataSpecificationIec61360/valueList shall be empty, and vice versa
-| |AASc-3a-050 |New |Constraint AASc-050: If the DataSpecificationContent DataSpecificationIec61360 is used for an element, the value of HasDataSpecification/dataSpecification shall contain the global reference to the IRI of the corresponding data specification template \https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/0
+|(x) |AASc-3a-003 |New a|Constraint AASc-3a-003: For a _ConceptDescription_ referenced via _ValueList/valueId_ and using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/0), _DataSpecificationIec61360/value_ shall be set.
+|(x) |AASc-3a-004 |New a|Constraint AASc-004: For a ConceptDescription with category PROPERTY or VALUE using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/0), DataSpecificationIec61360/dataType is mandatory and shall be defined.
+|(x) |AASc-3a-005 |New a|Constraint AASc-005: For a ConceptDescription with category REFERENCE using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/0), DataSpecificationIec61360/dataType is STRING by default.
+|(x) |AASc-3a-006 |New a|Constraint AASc-006: For a ConceptDescription with category DOCUMENT using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/0), DataSpecificationIec61360/dataType shall be one of the following values: STRING or URL.
+|(x) |AASc-3a-007 |New a|Constraint AASc-007: For a ConceptDescription with category QUALIFIER_TYPE using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/0), DataSpecificationIec61360/dataType is mandatory and shall be defined.
+|(x) |AASc-3a-008 |New a|Constraint AASc-3a-008: For a ConceptDescription using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/0), DataSpecificationIec61360/definition is mandatory and shall be defined at least in English. Exception: the concept description describes a value, i.e. DataSpecificationIec61360/value is defined.
+|(x) |AASc-3a-009 |New a|Constraint AASc-009: If DataSpecificationIec61360/dataType is one of INTEGER_MEASURE, REAL_MEASURE, RATIONAL_MEASURE, INTEGER_CURRENCY, REAL_CURRENCY, then DataSpecificationIec61360/unit or DataSpecificationIec61360/unitId shall be defined.
+|(x) |AASc-3a-010 |New a|Constraint AASc-010: If DataSpecificationIec61360/value is not empty, DataSpecificationIec61360/valueList shall be empty, and vice versa
+| |AASc-3a-050 |New a|Constraint AASc-050: If the DataSpecificationContent DataSpecificationIec61360 is used for an element, the value of HasDataSpecification/dataSpecification shall contain the global reference to the IRI of the corresponding data specification template \https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/0
 |===
 
 

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/IDTA-01003-a_ChangeLog.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/IDTA-01003-a_ChangeLog.adoc
@@ -146,7 +146,7 @@ reference." (https://github.com/admin-shell-io/aas-specs-iec61360/issues/5[#5])
 .New, Changed or Removed Constraints in V3.0.1
 [width="100%",cols="7%,12%,15%,66%",options="header",]
 |===
-h|nc h|V3.0 vs. V3.0.1 h|New, Update, Removed, Reformulated h|Comment
+h|nc h|V3.0.1 vs. V3.0 h|New, Update, Removed, Reformulated h|Comment
 
 | | AASc-3a-003 | Update a| Change http to https
 

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/IDTA-01003-a_Intro.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/IDTA-01003-a_Intro.adoc
@@ -12,19 +12,19 @@ SPDX-License-Identifier: CC-BY-4.0
 
 ==  Introduction
 
-This document is part of the series "Details of the Asset Administration Shell" that provide the specifications for interoperable usage of the Asset Administration Shell.
+This document is part of the series "Specification of the Asset Administration Shell" that provide the specifications for interoperable usage of the Asset Administration Shell.
 
-This part of the series extends Part 1 and defines a technology-neutral specification of data specification templates, enabling the description of concept descriptions conformant to IEC 61360 in UML. This UML meta model serves as the basis for deriving several different formats for exchanging Asset Administration Shells, e.g. for XML, JSON, RDF, AutomationML, and OPC UA information models.
+This part defines a technology-neutral specification of a data specification template, enabling the description of concept descriptions conformant to IEC 61360 in UML. This UML meta model serves as the basis for deriving several different formats for exchanging Asset Administration Shells, e.g. for XML, JSON, RDF as described in Part 1 of the document series (IDTA-01001). Data Specification Templates are implemented using the embedded data specification approach. This means, that the implementation is part of the overall schemas as defined for IDTA-01001.
 
-_<<#_Toc129706725,Figure 1>>_ shows the different ways of exchanging information via Asset Administration Shells. This part of the "Asset Administration Shell in Detail" series is the basis for all of these types of information exchange.
+_<<#_Toc129706725,Figure 1>>_ shows the different ways of exchanging information via Asset Administration Shells. This part of the "Specification of the Asset Administration Shell" series is the basis for all of these types of information exchange.
 
 [#_Toc129706725]
 .Types of Information Exchange via Asset Administration Shells
 image::image2.jpeg[align=center]
 
-File exchange (1) is described in Part 5 of this document series.
+File exchange (1) is described in Part 5 of this document series (IDTA-01005).
 
-The API (2) is specified in Part 2 of the document series "Details of the Asset Administration Shell" link:#bib14[[14\]]. It also includes access to concept descriptions using the data specifications as specified in this document.
+The API (2) is specified in Part 2 of the document series "Specification of the Asset Administration Shell" (IDTA-01002) link:#bib14[[14\]]. It also includes access to concept descriptions using the data specifications as specified in this document.
 
 The I4.0 language (3) is based on the information metamodel specified in Part 1 and 3 link:#bib23[[23\]].
 
@@ -54,9 +54,9 @@ The data specification template IEC 61360 introduces additional attributes to de
 
 IEC 61360 requests to use IRDIs for the identification of a concept. The Asset Administration Shell allows to use other identifiers besides IRDI. The IRDI, the unique identifier of an IEC 61360 property or value, maps to ConceptDescription/id.
 
-_<<#_Toc129706726,Figure 2>>_ to _<<#_Toc129706729,Figure 5>>_ show examples from ECLASS _<<#_Toc129706727,Figure 3>>_ shows a property with enumeration type. One of the values in this enumeration is shown in _<<#_Toc129706728,Figure 4>>_, each value has its own unique ID. The unique identifier of a value ( _<<#_Toc129706728,Figure 4>>_) is also used for _Property/valueId._
+_<<#_Toc129706726,Figure 2>>_ to _<<#_Toc129706729,Figure 5>>_ show examples from ECLASS. _<<#_Toc129706727,Figure 3>>_ shows a property with enumeration type. One of the values in this enumeration is shown in _<<#_Toc129706728,Figure 4>>_, each value has its own unique ID. The unique identifier of a value (_<<#_Toc129706728,Figure 4>>_) is also used for _Property/valueId._
 
-_<<#_Ref129950722,Figure 6>>_ Example for Property with Level Type from IEC CDD shows an example from IEC CDD for a concept description of a _Property_ with usage of Level Type (in this example level type MIN, MAX and NOM, see data type). This is a short form of defining a collection of three properties with the same data type and semantics except for the level.
+_<<#_Ref129950722,Figure 6>> shows an example from IEC CDD for a concept description of a _Property_ with usage of Level Type (in this example level type MIN, MAX and NOM, see data type). This is a short form of defining a collection of three properties with the same data type and semantics except for the level.
 
 
 [#_Toc129706726]
@@ -89,7 +89,7 @@ There is one data specification template supporting IEC 61360 [IEC61360-1]:
 
 * _DataSpecificationIec61360:_ defining concept descriptions for both properties and coded values.
 
-_<<#_Ref129879629,Figure 7>>_ Overview Relationship Metamodel Part 1 a & Data Specifications IEC 61360 gives an overview of the data specification template and how it is used in combination with the information model as defined in Part 1 of the document series, namely _DataSpecification_, _DataSpecificationContent,_ and _ConceptDescription_.
+_<<#_Ref129879629,Figure 7>>_ Overview Relationship Metamodel Part 1 a & Data Specifications IEC 61360 gives an overview of the data specification template and how it is used in combination with the information model as defined in Part 1 of the document series, namely  _DataSpecification_, _DataSpecificationContent,_ and _ConceptDescription_.
 
 [#_Ref129879629]
 .Overview Relationship Metamodel Part 1 a & Data Specifications IEC 61360
@@ -99,6 +99,3 @@ IEC 61360 is a standard that describes how to define the semantics of properties
 
 The legend for understanding the UML diagrams and the table specification of the classes is explained in xref:sharedAnnex/IDTA-01xxx_UMLTemplates.adoc[] and xref:sharedAnnex/IDTA-01xxx_UML.adoc[].
 
-====
-Note: an xmi representation of the UML model can be found in the repository "aas-specs" in the github project admin-shell-io: https://github.com/admin-shell-io/aas-specs/.
-====

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/IDTA-01003-a_Preamble.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/IDTA-01003-a_Preamble.adoc
@@ -12,7 +12,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 ===  Scope of This Document
 
-The Asset Administration Shell (see Part 1a of the document series) allows to define data specification templates. Data specification templates aim to enable interoperability between the partners that agree on the template. A template defines a set of attributes, with each attribute having a clear semantics. This set of attributes corresponds to a (sub-)schema.
+The Asset Administration Shell (see Part 1 of the document series, IDTA-01001) allows to define data specification templates. Data specification templates aim to enable interoperability between the partners that agree on the template. A template defines a set of attributes, with each attribute having a clear semantics. This set of attributes corresponds to a (sub-)schema.
 
 This document specifies data specification templates conformant to IEC 61360. IEC 61360 specifies how to define the semantics of single properties or values. The value range of a property can be defined as a value list – an enumeration -, while each of the (coded) values of the value list are treated as single concepts. They are thus suited to be used as data specifications for concept descriptions.
 
@@ -24,7 +24,7 @@ Please consult the continuously updated reading guide link:#bib15[[15\]] for an 
 
 === Normative References
 
-[AAS-Part1] "The Exchange of information between partners in the value chain of Industrie 4.0", part of document series "Details of the Asset Administration Shell". V3.0. Jan. 2023. Industrial Digital Twin Association.
+[IDTA-01001] "Specification of the Asset Administration Shell. Part 1: Metamodel", IDTA-01001-3-1. Industrial Digital Twin Association.
 
 [IEC61360-1] Standard data element types with associated classification scheme – Part 1: Definitions – Principles and methods. Edition 4.0 2017-07
 

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/IDTA-01003-a_Specification.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/IDTA-01003-a_Specification.adoc
@@ -8,6 +8,8 @@ SPDX-License-Identifier: CC-BY-4.0
 
 ////
 
+include::includes/constraints.adoc[]
+
 = Specification
 
 == Predefined Template for IEC61360 Properties, Value Lists, and Values (normative)
@@ -23,7 +25,16 @@ This specification is only valid in combination with IDTA-01001-3-1.
 h|*Template:* 3+|IEC61360
 h|*administration:* |version: 3 |revision: 1 |creator: IDTA
 
-h|*id:* 3+a|`\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1`
+h|*id:* 3+a|`\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3`
+
+
+\<<deprecated>> `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/0`
+
+\<<deprecated>> `\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/0`
+
+\<<deprecated>> `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0`
+
+\<<deprecated>> `\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0`
 
 
 h|*dataSpecificationContent:* |DataSpecificationIec61360 | |
@@ -59,9 +70,10 @@ Content of data specification template for concept descriptions for properties, 
 Note: for details, please refer to [IEC61360-1], property, value_list and term
 ====
 
-
+{aasc3a010}
+////
 +++Constraint AASc-010+++: If _DataSpecificationIec61360/value_ is not empty, _DataSpecificationIec61360/valueList_ shall be empty, and vice versa.
-
+////
 
 ====
 Note 1: it is also possible that both _DataSpecificationIec61360/value_ and _SpecificationIec61360/valueList_ are empty. This is the case for concept descriptions that define the semantics of a property but do not have an enumeration (_valueList)_ as data type.
@@ -73,9 +85,10 @@ Note 1: it is also possible that both _DataSpecificationIec61360/value_ and _Spe
 Note 2: although it is possible to define a concept description for a value list, it is not possible to reuse this value list. It is only possible to directly add a value list as data type to a specific semantic definition of a property.
 ====
 
-
-+++Constraint AASc-009:+++ If _DataSpecificationIec61360/­dataType_ is one of _INTEGER_MEASURE, REAL_MEASURE, RATIONAL_MEASURE, INTEGER_CURRENCY,_ _REAL_CURRENCY_, then _DataSpecificationIec61360/unit_ or _DataSpecificationIec61360/unitId_ shall be defined.
-
+{aasc3a009}
+////
++++Constraint AASc-009:+++ If _DataSpecificationIec61360/dataType_ is one of _INTEGER_MEASURE, REAL_MEASURE, RATIONAL_MEASURE, INTEGER_CURRENCY,_ _REAL_CURRENCY_, then _DataSpecificationIec61360/unit_ or _DataSpecificationIec61360/unitId_ shall be defined.
+////
 
 |*Inherits from:* 3+|DataSpecificationContent 
 
@@ -88,8 +101,10 @@ Preferred name in different languages
 Note: for details, please refer to [IEC61360-1], preferred_name
 ====
 
-
-+++Constraint AASc-002+++: _Data­Specification­Iec61360­/preferredName_ shall be provided at least in English.
+{aasc3a002}
+////
++++Constraint AASc-002+++: _DataSpecificationIec61360/preferredName_ shall be provided at least in English.
+////
 
 |PreferredNameTypeIec61360 |1
 |shortName a|
@@ -136,7 +151,7 @@ Note 2: it is recommended to use an external reference ID.
 
 
 |Reference |0..1
-|sourceOf­Definition a|
+|sourceOfDefinition a|
 Source of definition
 
 
@@ -219,7 +234,7 @@ Value represented by up to four variants of a numeric value in a specific role: 
 ====
 Note: for details, please refer to [IEC61360-1], LEVEL_TYPE
 ====
-(MIN,NOM,TYP,MAX)
+
 
 |LevelType |0..1
 |===
@@ -552,29 +567,18 @@ Note: This is how the AAS deals with the following combinations of level types:
 ====
 
 
+* Case 1: If all attributes are false, the concept is mapped to a Property and level type is ignored.
+
+* Case2: If a maximum of one attribute is set to true, the concept is mapped to a Property.
+
+* Case 3: If min and max are set to true, the concept is mapped to a Range.
 
 
-
-____
-If all attributes are false, the concept is mapped to a Property and level type is ignored.
-____
+* Case 4: If more than one attribute is set to true, does not include min and max only (see second case), the concept is mapped to a _SubmodelElementCollection_ with the corresponding number of Properties. Example: If the attributes min and nom are set to true, the concept is mapped to a _SubmodelElementCollection_ with two Properties: min and nom. The data type of both Properties is the same.
 
 
-____
-If a maximum of one attribute is set to true, the concept is mapped to a Property.
-____
+In the cases 2 and 4, the _semanticId_ of the Property or Properties within the _SubmodelElementCollection_ needs to include information about the level type. Otherwise, the semantics is not described in a unique way. In link:#bib27[[27\]], IRDI paths are introducedfootnote:[see also https://eclass.eu/support/technical-specification/data-model/irdi-path]. 
 
-
-____
-If min and max are set to true, the concept is mapped to a Range.
-____
-
-
-____
-If more than one attribute is set to true, does not include min and max only (see second case), the concept is mapped to a _SubmodelElementCollection_ with the corresponding number of Properties. Example: If the attributes min and nom are set to true, the concept is mapped to a _SubmodelElementCollection_ with two Properties: min and nom. The data type of both Properties is the same.
-____
-
-In the cases 2 and 4, the _semanticId_ of the Property or Properties within the _SubmodelElementCollection_ needs to include information about the level type. Otherwise, the semantics is not described in a unique way. In link:#bib27[[27\]], IRDI paths are introduced. However, no rules of how to map IRDI paths to __Reference__s for semanticIds have yet been defined.
 
 It is not recommended to use level type when defining concept descriptions for Properties, except for ranges (i.e. min and max). This is considered to be a deprecated way of defining property sets. See also link:#bib27[[27\]], where one proposal on how to deal with level type is to remove the level type and to define several properties instead.
 
@@ -636,6 +640,7 @@ Examples for the different IEC 61360 data types can be found here: https://eclas
 [width="100%",cols="31%,30%,39%",options="header",]
 |===
 |*Data Type IEC 61360* |*xsd Value Type*footnote:[_Property/valueType_, _Range/valueType,_ etc. are each of type _DataTypeDefXsd._ 
+
 ====
 Note: for submodel elements like _Blob_ and _File_ or _MultiLanguageProperty and ReferenceElement,_ there is no explicitly defined _valueType_ attribute because the data type is implicitly defined and fix (_BlobType_, _PathType_ or _MultiLanguageTextType, Reference_).] |*Example Values IEC 61360*footnote:[Source for most examples for the different IEC 61360 data types: https://eclass.eu/support/technical-specification/structure-and-elements/value. The IRDI example for STRING was moved to IRDI.]
 ====
@@ -784,16 +789,16 @@ image::image13.png[align=center]
 
 [width="100%",cols="31%,13%,13%,9%,18%,16%"]
 |===
-h|Attribute footnote:[m = mandatory, o = optional, (m) = conditionally mandatory or recommended to be added] h|Property h|Property h|Property h|Multi­Language­Property h|Range
+h|Attribute footnote:[m = mandatory, o = optional, (m) = conditionally mandatory or recommended to be added] h|Property h|Property h|Property h|MultiLanguageProperty h|Range
 h|Category of Concept Description h|VALUE h|PROPERTY h|PROPERTY h|PROPERTY h|PROPERTY
-h|Category of Submodel­Element­ h|CONSTANT h|VARIABLE h|PARAMETER h|-- h|--
+h|Category of SubmodelElement h|CONSTANT h|VARIABLE h|PARAMETER h|-- h|--
 e|preferredNamefootnote:[Mandatory in at least one language. Preferably, an English preferred name should always be defined.] |m |m |m |m |m
 e|shortName |(m) |(m) |(m) |(m) |(m)
 e|unit |(m) |(m) |(m) |-- |(m)
 e|unitId |(m) |(m) |(m) |-- |(m)
-e|sourceOf­Definition |o |o |o |o |o
+e|sourceOfDefinition |o |o |o |o |o
 e|symbol |o |o |o |-- |--
-e|dataType |mfootnote:[All IEC 61360 data types except STRING_TRANSLATABLE, IRI, IRDI, HTML, FILE, BLOB.] |m^8^ |m^8^ |STRING_TRANSLATABLE |INTEGER_* or REAL_­*
+e|dataType |mfootnote:[All IEC 61360 data types except STRING_TRANSLATABLE, IRI, IRDI, HTML, FILE, BLOB.] |m^8^ |m^8^ |STRING_TRANSLATABLE |INTEGER_* or REAL_*
 e|definition |(m) |m |m |m |m
 e|valueFormat |o |o |o |-- |o
 e|valueList |-- |o |o |-- |--
@@ -813,14 +818,14 @@ Max = true
 
 [width="99%",cols="22%,13%,13%,13%,13%,13%,13%",options="header",]
 |===
-|*Attribute**^6^* |*Reference­Element* |*File*footnote:[Template only used until explicit template is available for defining the corresponding types of elements.] |*Blob^9^* |*Capability^9^* |*Relationship­Element^9^* |*AnnotatedRelationship­Element^9^*
+|*Attribute**^6^* |*ReferenceElement* |*File*footnote:[Template only used until explicit template is available for defining the corresponding types of elements.] |*Blob^9^* |*Capability^9^* |*RelationshipElement^9^* |*AnnotatedRelationshipElement^9^*
 h|Category of Concept Description h|REFERENCE h|DOCUMENT h|DOCUMENT h|CAPABILITY h|RELATIONSHIP h|RELATIONSHIP
-|*Category of Submodel­Element­* |*--* |*--* |*--* |*--* |*--* |*--*
+|*Category of SubmodelElement* |*--* |*--* |*--* |*--* |*--* |*--*
 |preferredName^7^ |m |m |m |m |m |m
 |shortName |(m) |(m) |(m) |(m) |(m) |(m)
 |unit |-- |-- |-- |-- |-- |--
 |unitId |-- |-- |-- |-- |-- |--
-|sourceOf­Definition |o |o |o |o |o |o
+|sourceOfDefinition |o |o |o |o |o |o
 |symbol |-- |-- |-- |-- |-- |--
 |dataType |string or Iri or Irdi or Icid or iso29002Irdi |file |blob or html5 |-- |-- |--
 |definition |m |m |m |m |m |m
@@ -840,12 +845,12 @@ h|Category of Concept Description h|REFERENCE h|DOCUMENT h|DOCUMENT h|CAPABILITY
 |===
 |*Attribute* |*SubmodelElementList^9^* |*SubmodelElementCollection^9^* |*Operation^9^* |*EventElement^9^* |*Entity^9^*
 h|Category of Concept Description h|COLLECTION h|ENTITY h|FUNCTION h|EVENT h|ENTITY
-|*Category of Submodel­Element­* |*--* |*--* |*--* |*--* |*--*
+|*Category of SubmodelElement* |*--* |*--* |*--* |*--* |*--*
 |preferredName^7^ |m |m |m |m |m
 |shortName |(m) |(m) |(m) |(m) |(m)
 |unit |-- |-- |-- |-- |--
 |unitId |-- |-- |-- |-- |--
-|sourceOf­Definition |o |o |o |o |o
+|sourceOfDefinition |o |o |o |o |o
 |symbol |-- |-- |-- |-- |--
 |dataType |-- |-- |-- |-- |--
 |definition |m |m |m |m |m
@@ -896,50 +901,63 @@ https://sunye.github.io/ocl/[A class invariant is a constraint that must be true
 
 
 ====
-Note: these constraints include elements of Part 1, V3.0 of the document series "Details of the Asset Administration Shell" [AAS-Part1].
+Note: these constraints include elements of Part 1 Metamodel, IDTA-01001. 
 ====
 
 {empty}
 
 === Constraints for Data Specification IEC61360
 
+{aasc3a004}
+////
 +++Constraint AASc-3a-004+++: For a _ConceptDescription_ with _category_ _PROPERTY_ or _VALUE_ using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1), _DataSpecificationIec61360/dataType_ is mandatory and shall be one of _DATE, STRING, STRING_TRANSLATABLE, INTEGER_MEASURE, INTEGER_COUNT, INTEGER_CURRENCY, REAL_MEASURE, REAL_COUNT, REAL_CURRENCY, BOOLEAN, RATIONAL, RATIONAL_MEASURE, TIME, TIMESTAMP_.
-
-
-====
-Note: categories are deprecated since V3.0 of Part 1 of the document series "Details of the Asset Administration Shell".
-====
-
-
-+++Constraint AASc-3a-005:+++ For a _ConceptDescription_ with _category_ REFERENCE using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1), _DataSpecificationIec61360/dataType_ shall be one of _STRING, IRI, IRDI._
-
+////
 
 ====
 Note: categories are deprecated since V3.0 of Part 1 of the document series "Details of the Asset Administration Shell".
 ====
 
+{aasc3a005}
+////
++++Constraint AASc-3a-004+++: For a _ConceptDescription_ with _category_ _PROPERTY_ or _VALUE_ using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1), _DataSpecificationIec61360/dataType_ is mandatory and shall be one of _DATE, STRING, STRING_TRANSLATABLE, INTEGER_MEASURE, INTEGER_COUNT, INTEGER_CURRENCY, REAL_MEASURE, REAL_COUNT, REAL_CURRENCY, BOOLEAN, RATIONAL, RATIONAL_MEASURE, TIME, TIMESTAMP_.
+////
 
+====
+Note: categories are deprecated since V3.0 of Part 1 of the document series "Details of the Asset Administration Shell".
+====
+
+{aasc3a006}
+////
 +++Constraint AASc-3a-006+++: For a _ConceptDescription_ with _category_ DOCUMENT using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1), _DataSpecificationIec61360/dataType_ shall be one of _FILE, BLOB, HTML_.
-
+////
 
 ====
 Note: categories are deprecated since V3.0 of Part 1 of the document series "Details of the Asset Administration Shell".
 ====
 
-
+{aasc3a007}
+////
 +++Constraint AASc-3a-007:+++ For a _ConceptDescription_ with _category_ QUALIFIER_TYPE using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1), _DataSpecificationIec61360/dataType_ is mandatory and shall be defined.
-
+////
 
 ====
 Note: categories are deprecated since V3.0 of Part 1 of the document series "Asset Administration Shell Specification".
 ====
 
-
+{aasc3a008}
+////
 +++Constraint AASc-3a-008+++: For a _ConceptDescription_ using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1), _DataSpecificationIec61360/definition_ is mandatory and shall be defined at least in English. Exception: the concept description describes a value, i.e. _DataSpecificationIec61360/value_ is defined.
+////
 
+{aasc3a003}
+////
 +++Constraint AASc-3a-003+++: For a _ConceptDescription_ referenced via _ValueList/valueId_ and using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1), _DataSpecificationIec61360/value_ shall be set.
+////
 
+{aasc3a050}
+////
 +++Constraint AASc-3a-050+++: If the _DataSpecificationContent_ _DataSpecificationIec61360_ is used for an element, the value of _HasDataSpecification/dataSpecification_ shall contain the external reference to the IRI of the corresponding data specification template \https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1.
+////
 
 == Primitive and Simple Data Types (normative)
 
@@ -1003,7 +1021,7 @@ The realization of a technology depend on the serialization rules.
 
 
 ====
-Note: as defined in Part 1, [AAS-Part1].
+Note: as defined in Part 1 Metamode, IDTA-01001.
 ====
 
 
@@ -1022,9 +1040,11 @@ In rdf:
 
 In JSON:
 
+[source,json,linenums]
+----
 "description": [
 
-  \{
+  {
 
       "language":"en", 
 
@@ -1032,7 +1052,7 @@ In JSON:
 
   },
 
-  \{
+  {
 
 "language":"de",
 
@@ -1041,6 +1061,7 @@ In JSON:
    }
 
 ]
+----
 
 |PreferredNameTypeIec61360 a|
 _LangStringSet_
@@ -1118,75 +1139,9 @@ Note: see _<<#_Ref129950722,Figure 6>>_
 
 === General
 
-Part 1 of the document series introduces the need for different serialization formats and described when which format is used. Part 1 also introduces the implementation guide for embedded data specifications. Hence, only the links to the different schemas derived for the formats XML, JSON, and RDF are provided in the following. Further information can be found in [AAS-Part1].
-
-=== XML
-
-The metamodel of an Asset Administration Shell needs to be serialized for import and export scenarios. XML is a possible serialization format.
-
-
-====
-Note 1: the xml schema (.xsd files) is maintained in the repository "aas-spec" of the github project admin-shell-io link:#bib25[[25\]]: aas-specs-3.0\schemas\xml.
-====
-
-
-
-====
-Note 2: the mapping rules of how to derive the xml schema from the technology-neutral metamodel as defined in this specification can be found here: aas-specs-3.0\schemas\xml\Readme.md#xml-mappingrules.
-====
-
-
-
-====
-Note 3: example files can be found here: aas-specs-3.0\schemas\xml\examples.
-====
-
-
-===  JSON
-
-JSONfootnote:[see: https://tools.ietf.org/html/rfc8259 or https://www.ecma-international.org/publications/standards/Ecma-404.htm] (JavaScript Object Notation) is a further serialization format that serializes the metamodel of an Assest Administration Shell for import and export scenarios.
-
-Additionally, JSON format is used to describe the payload in the http/REST API for active Asset Administration Shells link:#bib14[[14\]].
-
-
-====
-Note 1: the JSON schema (.json files) is maintained in the repository "aas-spec" of the github project admin-shell-io link:#bib25[[25\]]: h aas-specs-3.0\schemas\json
-====
-
-
-
-====
-Note 2: the mapping rules of how to derive the JSON schema from the technology-neutral metamodel as defined in this specification can be found here: aas-specs-3.0\schemas\json\Readme.md#json-mappingrules
-====
-
-
-
-====
-Note 3: example files can be found here: aas-specs-3.0\schemas\json\examples.
-====
-
-
-===  RDF
-
-The Resource Description Framework (RDF) link:#bib26[[26\]] is the recommended standard of the W3C to unambiguously model and present semantic data. RDF documents are structured in the form of triples, consisting of subjects, relations, and objects. The resulting model is often interpreted as a graph, with the subject and object elements as the nodes and the relations as the graph edges.
-
-
-====
-Note 1: the RDF scheme/OWL files (.ttl files) are maintained in the repository "aas-spec" of the github project admin-shell-io link:#bib25[[25\]]: aas-specs-3.0\schemas\rdf
-====
-
-
-
-====
-Note 2: the mapping rules of how to derive the RDF schema from the technology-neutral metamodel as defined in this specification can be found here: aas-specs-3.0\schemas\rdf\Readme.md#rdf-mappingrules
-====
-
-
-
-====
-Note 3: example files can be found here: aas-specs-3.0\schemas\rdf\examples
-====
-
+Part 1 of this document series (IDTA-01001) introduces different serialization formats: XML, JSON and RDF. 
+Part 1 also introduces the implementation guide for embedded data specifications. 
+This is why the different formats are described in IDTA-01001.
 
 
 

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/includes/constraints.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/includes/constraints.adoc
@@ -1,0 +1,31 @@
+////
+Copyright (c) 2023 Industrial Digital Twin Association
+
+This work is licensed under a [Creative Commons Attribution 4.0 International License](
+https://creativecommons.org/licenses/by/4.0/). 
+
+SPDX-License-Identifier: CC-BY-4.0
+////
+
+// Constraints
+
+
+:aasc3a002: pass:q[[underline]#Constraint AASc-3a-002:# _DataSpecificationIec61360/preferredName_ shall be provided at least in English.]
+
+:aasc3a003: pass:q[[underline]#Constraint AASc-3a-002:#For a _ConceptDescription_ referenced via _ValueList/valueId_ and using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3), _DataSpecificationIec61360/value_ shall be set.]
+
+:aasc3a004: pass:q[[underline]#Constraint AASc-3a-004:# For a _ConceptDescription_ with _category_ _PROPERTY_ or _VALUE_ using data specification template IEC61360 (`\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3`), _DataSpecificationIec61360/dataType_ is mandatory and shall be one of _DATE, STRING, STRING_TRANSLATABLE, INTEGER_MEASURE, INTEGER_COUNT, INTEGER_CURRENCY, REAL_MEASURE, REAL_COUNT, REAL_CURRENCY, BOOLEAN, RATIONAL, RATIONAL_MEASURE, TIME, TIMESTAMP_.]
+
+:aasc3a005: pass:q[[underline]#Constraint AASc-3a-005:# For a _ConceptDescription_ with _category_ _REFERENCE_ using data specification template IEC61360 (`\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3`), _DataSpecificationIec61360/dataType_ shall be one of STRING, IRI, IRDI.]
+
+:aasc3a006: pass:q[[underline]#Constraint AASc-3a-006:# For a _ConceptDescription_ with _category_ DOCUMENT using data specification template IEC61360 (`\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3`), _DataSpecificationIec61360/dataType_ shall be one of _FILE, BLOB, HTML_.]
+
+:aasc3a007: pass:q[[underline]#Constraint AASc-3a-007:# For a _ConceptDescription_ with _category_ QUALIFIER_TYPE using data specification template IEC61360 (`\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3`), _DataSpecificationIec61360/dataType_ is mandatory and shall be defined.]
+
+:aasc3a008: pass:q[[underline]#Constraint AASc-3a-008:# For a _ConceptDescription_ using data specification template IEC61360 (`\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3`), _DataSpecificationIec61360/definition_ is mandatory and shall be defined at least in English. Exception: the concept description describes a value, i.e. _DataSpecificationIec61360/value_ is defined.]
+
+:aasc3a009: pass:q[[underline]#Constraint AASc-3a-009:# If _DataSpecificationIec61360/dataType_ is one of _INTEGER_MEASURE, REAL_MEASURE, RATIONAL_MEASURE, INTEGER_CURRENCY,_ _REAL_CURRENCY_, then _DataSpecificationIec61360/unit_ or _DataSpecificationIec61360/unitId_ shall be defined.]
+
+:aasc3a010: pass:q[[underline]#Constraint AASc-3a-010:# If _DataSpecificationIec61360/value_ is not empty, _DataSpecificationIec61360/valueList_ shall be empty, and vice versa.]
+
+:aasc3a050: pass:q[[underline]#Constraint AASc-3a-050:# If the _DataSpecificationContent_ _DataSpecificationIec61360_ is used for an element, the value of _HasDataSpecification/dataSpecification_ shall contain the external reference to the IRI of the corresponding data specification template `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3`.]

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/index.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/index.adoc
@@ -11,11 +11,11 @@ This specification is part of the https://industrialdigitaltwin.org/en/content-h
 == Version
 This is version 3.1 of the specification IDTA-01003-a.
 
-Previous version: 3.0.1
+Previous version: 3.0.2
 
 == Notice
 
-Publisher:  Industrial Digital Twin Association e.V. (IDTA)
+Publisher and Copyright:  Industrial Digital Twin Association e.V. (IDTA)
 
 IDTA Document Number: IDTA-01003-a-3-1
 


### PR DESCRIPTION
fix: Usage of deprecated data spec. template ID in constraints
https://github.com/admin-shell-io/aas-specs-iec61360/issues/29

fix: rename constraints to include -3a- to be conformant to naming convention
https://github.com/admin-shell-io/aas-specs-iec61360/issues/29

new file for constraints (similar to Part 1), constraints are included

+ added note in Annex “Handling of Constraints”: If a constraint is mentioning the id of the Template, then the same constraints shall also be valid for deprecated data specification template IDs

correction if "AAS in Details" was still used to "Specification of the AAS"

removal of mapping to xml, JSON, rdf because explained in Part 1, reformulations in text