### PR TITLE
Editorial changes 

### DIFF
--- a/documentation/IDTA-01003-a/modules/ROOT/pages/annex/backus-naur-form.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/annex/backus-naur-form.adoc
@@ -46,7 +46,7 @@ where:
 
 <e-mail-Addresses> ::= {<e-mail-Address>}*
 
-<e-mail-Addresse> ::= <local-part> "@" <domain>
+<e-mail-Address> ::= <local-part> "@" <domain>
 
 <name> ::= characters
 

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/annex/uml-templates.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/annex/uml-templates.adoc
@@ -46,7 +46,7 @@ A metamodel ID for a class attribute is concatenated by _<ID of metamodel elemen
 The following stereotypes can be used:
 
 * \<<abstract>>: Class cannot be instantiated but serves as superclass for inheriting classes
-* \<<Experimental>>: Class is experimental, i.e. usage is only recommended for experimental purposes because non backward compatible changes may occur in future versions
+* \<<Experimental>>: Class is experimental, i.e. usage is only recommended for experimental purposes because non-backward compatible changes may occur in future versions
 * \<<Deprecated>>: Class is deprecated, i.e. it is recommended to not use the element any longer; it will be removed in a next major version of the model
 * \<<Template>>: Class is a template only, i.e. class is not instantiated but used for additional specification purposes (for details see parts 3 of document series)
 

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/bibliography.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/bibliography.adoc
@@ -58,10 +58,6 @@ Dec. 2022. Industrial Digital Twin Association.
 [Online].
 Available: https://industrialdigitaltwin.org/wp-content/uploads/2022/12/I40-IDTA-WS-Process-How-to-write-a-SMT-FINAL-.pdf
 
-[#bib25]
-[25] "AAS Repository.
-Repository for Information and Code for the Asset Administration Shell". https://github.com/admin-shell-io
-
 [#bib27]
 [27] "Modelling the Semantics of Data of an Asset Administration Shell with Elements of ECLASS".
 June 2021. 

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/bibliography.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/bibliography.adoc
@@ -10,50 +10,6 @@ SPDX-License-Identifier: CC-BY-4.0
 [bibliography]
 = Bibliography
 
-[#bib1]
-[1] "Recommendations for implementing the strategic initiative INDUSTRIE 4.0", acatech, April 2013. [Online].
-Available: https://www.acatech.de/Publikation/recommendations-for-implementing-the-strategic-initiative-industrie-4-0-final-report-of-the-industrie-4-0-working-group/
-
-[#bib2]
-[2] "Implementation Strategy Industrie 4.0: Report on the results of the Industrie 4.0 Platform"; BITKOM e.V. / VDMA e.V., /ZVEI e.V., April 2015. [Online].
-Available: https://www.bitkom.org/noindex/Publikationen/2016/Sonstiges/Implementation-Strategy-Industrie-40/2016-01-Implementation-Strategy-Industrie40.pdf
-
-[#bib3]
-[3] DIN SPEC 91345:2016-04 "Referenzarchitekturmodell Industrie 4.0 (RAMI4.0) / Reference Architecture Model Industrie 4.0 (RAMI4.0) / Modèle de reference de l’architecture de l’industrie 4.0 (RAMI4.0)", ICS 03.100.01; 25.040.01; 35.240.50, April 2016. [Online].
-Available: https://www.beuth.de/en/technical-rule/din-spec-91345-en/250940128
-
-[#bib4]
-[4] "Structure of the Administration Shell, continuation of the development of the reference model for the Industrie 4.0 component", Plattform Industrie 4.0, Working Paper, April 2016. [Online].
-Available: https://www.plattform-i40.de/PI40/Redaktion/EN/Downloads/Publikation/structure-of-the-administration-shell.html
-
-[#bib5]
-[5] "Definition of terms relating to Industrie 4.0", Fraunhofer IOSB and VDI/VDE-GMA Fachausschuss 7.21.
-Accessed: 2020-11-14. [Online].
-Available../../../../../../../C:/Users/Torben/AppData/Local/Microsoft/Windows/INetCache/Content.Outlook/V9OOP350/%20http/i40.iosb.fraunhofer.de/_search[: http://i40.iosb.fraunhofer.de/_search?patterns=FA7.21%20Begriffe]
-
-[6] DIN SPEC 92000:2019-09 "Data Exchange on the Base of Property Value Statements (PVSX)", 2019 September.
-
-[#bib7]
-[7] "Verwaltungsschale in der Praxis.
-Wie definiere ich Teilmodelle, beispielhafte Teilmodelle und Interaktion zwischen Verwaltungsschalen (in German)", Version 1.0, April 2019, Plattform Industrie 4.0 in Kooperation mit VDI/VDE-GMA Fachausschuss 7.20, Federal Ministry for Economic Affairs and Energy (BMWi).
-Available: https://www.plattform-i40.de/PI40/Redaktion/DE/Downloads/Publikation/2019-verwaltungsschale-in-der-praxis.html
-
-[#bib8]
-[8] "The Structure of the Administration Shell: TRILATERAL PERSPECTIVES from France, Italy and Germany", March 2018, [Online].
-Available: https://www.plattform-i40.de/I40/Redaktion/EN/Downloads/Publikation/hm-2018-trilaterale-coop.html
-
-[#bib9]
-[9] "Industrial automation systems and integration — Exchange of characteristic data — Part 10: Characteristic data exchange format", Technical Specification ISO/TS 29002-10:2009(E), 2009
-
-[#bib10]
-[10] "Smart Manufacturing - Reference Architecture Model Industry 4.0 (RAMI4.0)", IEC PAS 63088, International Electrotechnical Commission (IEC), 2017
-
-[#bib11]
-[11] ISO/TS 29002-10:2009(E) "Industrial automation systems and integration — Exchange of characteristic data — Part 10: Characteristic data exchange format", First edition 2009-12-01
-
-[#bib12]
-[12] "OMG Unified Modelling Language (OMG UML)".
-Formal/2017-12-05. Version 2.5.1. December 2018. [Online] Available: https/www.omg.org/spec/UML/
 
 [#bib13]
 [13] T. Preston-Werner "Semantic Versioning".
@@ -62,6 +18,11 @@ Version 2.0.0. Accessed: 2020-11-13. [Online] Available: https://semver.org/spec
 [#bib14]
 [14] IDTA-01002 "Specification of the Asset Administration Shell Part 2 – Application Programming Interfaces".
 See xref:bibliography.adoc#bib22[[22\]].
+
+[#bib12]
+[12] "OMG Unified Modelling Language (OMG UML)".
+Version 2.5.1. December 2017. 
+[Online] Available: https://www.omg.org/spec/UML/2.5.1
 
 [#bib15]
 [15] "Asset Administration Shell.
@@ -72,27 +33,6 @@ November 2022. [Online] Available: https://industrialdigitaltwin.org/en/wp-conte
 [#bib16]
 [16] Top Level Project "Eclipse Digital Twin" Available: https://projects.eclipse.org/projects/dt
 
-[#bib17]
-[17] OPC 30270: OPC UA for Asset Administration Shell (AAS). 2021-06-04. [Online].
-Available: https://reference.opcfoundation.org/v104/I4AAS/v100/docs/
-
-[#bib18]
-[18] OPC Unified Architecture Specification.
-Part 5 Information Model. [Online].
-Available: https://opcfoundation.org/developer-tools/specifications-unified-architecture
-
-[#bib19]
-[19] OPC UA Information Models. [Online].
-Available: https://opcfoundation.org/developer-tools/specifications-opc-ua-information-models
-
-[#bib20]
-[20] IEC 63278-1 "Asset Administration Shell for industrial applications – Part 1: Asset Administration Shell structure". 95/925/CDV
-
-[#bib21]
-[21] "Registered AAS Submodel Templates".
-Industrial Digital Twin Association.
-Available: https://industrialdigitaltwin.org/en/content-hub/submodels
-
 [#bib22]
 [22] "Asset Administration Shell Specifications". [Online].
 Available: https://industrialdigitaltwin.org/en/content-hub/aasspecifications
@@ -101,6 +41,7 @@ Available: https://industrialdigitaltwin.org/en/content-hub/aasspecifications
 [23] (German) "I4.0-Sprache.
 Vokabular, Nachrichtenstruktur und semantische Interaktionsprotokolle der I4.0-Sprache", Discussion Paper.
 Plattform Industrie 4.0 [Online] Available: https://www.plattform-i40.de/IP/Redaktion/DE/Downloads/Publikation/hm-2018-sprache.html
+
 
 [#bib24]
 [24] "How to create a submodel template specification".
@@ -111,11 +52,15 @@ Available: https://industrialdigitaltwin.org/wp-content/uploads/2022/12/I40-IDTA
 [25] "AAS Repository.
 Repository for Information and Code for the Asset Administration Shell". https://github.com/admin-shell-io
 
-[#bib26]
-[26] F. Manola, E. Miller "RDF 1.1 Primer" W3C Recommendation, 2014, [Online].
-Available: https://www.w3.org/TR/rdf11-primer/
-
 [#bib27]
 [27] Modelling the Semantics of Data of an Asset Administration Shell with Elements of ECLASS.
 June 2021. [Online].
 Available: https://www.plattform-i40.de/IP/Redaktion/DE/Downloads/Publikation/Whitepaper_Plattform-Eclass.pdf
+
+
+
+
+
+
+
+

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/bibliography.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/bibliography.adoc
@@ -13,7 +13,8 @@ SPDX-License-Identifier: CC-BY-4.0
 
 [#bib13]
 [13] T. Preston-Werner "Semantic Versioning".
-Version 2.0.0. Accessed: 2020-11-13. [Online] Available: https://semver.org/spec/v2.0.0.html
+Version 2.0.0. Accessed: 2020-11-13. 
+[Online] Available: https://semver.org/spec/v2.0.0.html
 
 [#bib14]
 [14] IDTA-01002 "Specification of the Asset Administration Shell Part 2 – Application Programming Interfaces".
@@ -22,30 +23,39 @@ See xref:bibliography.adoc#bib22[[22\]].
 [#bib12]
 [12] "OMG Unified Modelling Language (OMG UML)".
 Version 2.5.1. December 2017. 
-[Online] Available: https://www.omg.org/spec/UML/2.5.1
+[Online]. 
+Available: https://www.omg.org/spec/UML/2.5.1
 
 [#bib15]
 [15] "Asset Administration Shell.
 Reading Guide".
 Industrial Digital Twin Association.
-November 2022. [Online] Available: https://industrialdigitaltwin.org/en/wp-content/uploads/sites/2/2022/12/2022-12-07_IDTA_AAS-Reading-Guide.pdf
+November 2022. 
+[Online].
+Available: https://industrialdigitaltwin.org/en/wp-content/uploads/sites/2/2022/12/2022-12-07_IDTA_AAS-Reading-Guide.pdf
 
 [#bib16]
 [16] Top Level Project "Eclipse Digital Twin" Available: https://projects.eclipse.org/projects/dt
 
 [#bib22]
-[22] "Asset Administration Shell Specifications". [Online].
+[22] "Asset Administration Shell Specifications". 
+[Online].
 Available: https://industrialdigitaltwin.org/en/content-hub/aasspecifications
 
 [#bib23]
 [23] (German) "I4.0-Sprache.
-Vokabular, Nachrichtenstruktur und semantische Interaktionsprotokolle der I4.0-Sprache", Discussion Paper.
-Plattform Industrie 4.0 [Online] Available: https://www.plattform-i40.de/IP/Redaktion/DE/Downloads/Publikation/hm-2018-sprache.html
+Vokabular, Nachrichtenstruktur und semantische Interaktionsprotokolle der I4.0-Sprache". 
+Discussion Paper.
+Plattform Industrie 4.0 
+[Online]. 
+Available: https://www.plattform-i40.de/IP/Redaktion/DE
+/Downloads/Publikation/hm-2018-sprache.html
 
 
 [#bib24]
 [24] "How to create a submodel template specification".
 Dec. 2022. Industrial Digital Twin Association.
+[Online].
 Available: https://industrialdigitaltwin.org/wp-content/uploads/2022/12/I40-IDTA-WS-Process-How-to-write-a-SMT-FINAL-.pdf
 
 [#bib25]
@@ -53,11 +63,18 @@ Available: https://industrialdigitaltwin.org/wp-content/uploads/2022/12/I40-IDTA
 Repository for Information and Code for the Asset Administration Shell". https://github.com/admin-shell-io
 
 [#bib27]
-[27] Modelling the Semantics of Data of an Asset Administration Shell with Elements of ECLASS.
-June 2021. [Online].
+[27] "Modelling the Semantics of Data of an Asset Administration Shell with Elements of ECLASS".
+June 2021. 
+[Online].
 Available: https://www.plattform-i40.de/IP/Redaktion/DE/Downloads/Publikation/Whitepaper_Plattform-Eclass.pdf
 
-
+[#bib28]
+[28] "How to transport ECLASS in the Asset Administration Shell".
+Guideline. 
+October 2024. 
+Publisher: Industrial Digital Twin Association & ECLASS 
+[Online]. 
+Available: https://industrialdigitaltwin.org/en/content-hub/downloads
 
 
 

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/changelog.adoc
@@ -41,7 +41,7 @@ Update all links to template ID in constraints
 
 * Transfer from .docx to asciidoc
 
-* Update Terms and Definitions to be compliant to IEC63278-1:2023 and other parts of specification
+* Update Terms and Definitions to be compliant to IEC63278-1:2023 and other parts of specification + add new term "coded value" (from Part 1)
 
 Minor changes:
 

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/index.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/index.adoc
@@ -37,7 +37,9 @@ Feedback:
 
 ==  Editorial Notes
 
-This document, version 3.1, was produced from Dec. 2022 on by the Workstream "Asset Administration Shell Specifications" of the working group o "Open Technology" of the Industrial Digital Twin Association (IDTA).
+=== History
+
+This document, version 3.1, was produced from Dec. 2022 on by the Workstream "Asset Administration Shell Specifications" of the working group "Open Technology" of the Industrial Digital Twin Association (IDTA).
 
 The document "Details of the Asset Administration Shell – Part 1 – The exchange of information between partners in the value chain of Industrie 4.0, V3.0RC02" was split into several parts.
 One of them is this document, which represents Part 3a and describes a data specification that is defined to be used with the core model as specified in Part 1.

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/introduction.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/introduction.adoc
@@ -65,7 +65,7 @@ IEC 61360 requests to use IRDIs for the identification of a concept.
 The Asset Administration Shell allows to use other identifiers besides IRDI.
 The IRDI, the unique identifier of an IEC 61360 property or value, maps to _ConceptDescription/id_.
 
-.Example Property From ECLASS
+.Example Property from ECLASS
 [[image-property-eclass]]
 image::image3.png[align=center]
 
@@ -103,11 +103,10 @@ For example, templates for concept descriptions differ from templates for operat
 More than one data specification template can be defined and used for an element instance.
 Which templates are used for an element instance is defined via _HasDataSpecification_.
 
-There is one data specification template supporting IEC 61360 [IEC61360-1]:
+This specification template _DataSpecificationIec61360:_ supports concept definitions conformant to IEC 61360 xref:preamble.adoc#IEC61360-1[[IEC61360-1\]] for both properties and coded values.
 
-* _DataSpecificationIec61360:_ defining concept descriptions for both properties and coded values.
 
-<<image-rel-metamodel-iec61360>> Overview Relationship Metamodel Part 1 a & Data Specifications IEC 61360 gives an overview of the data specification template and how it is used in combination with the information model as defined in Part 1 of the document series, namely  _DataSpecification_, _DataSpecificationContent,_ and _ConceptDescription_.
+<<image-rel-metamodel-iec61360>> gives an overview of the data specification template and how it is used in combination with the information model as defined in Part 1 of the document series, namely  _DataSpecification_, _DataSpecificationContent,_ and _ConceptDescription_.
 
 .Overview Relationship Metamodel Part 1 a & Data Specifications IEC 61360
 [[image-rel-metamodel-iec61360]]

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/introduction.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/introduction.adoc
@@ -63,18 +63,15 @@ The data specification template IEC 61360 introduces additional attributes to de
 
 IEC 61360 requests to use IRDIs for the identification of a concept.
 The Asset Administration Shell allows to use other identifiers besides IRDI.
-The IRDI, the unique identifier of an IEC 61360 property or value, maps to ConceptDescription/id.
-
-<<image-property-eclass>> to <<image-value-eclass-advanced>> show examples from ECLASS. <<image-property-value-list-eclass>> shows a property with enumeration type.
-One of the values in this enumeration is shown in <<image-value-eclass>>, each value has its own unique ID.
-The unique identifier of a value (<<image-value-eclass>>) is also used for _Property/valueId._
-
-<<image-property-level-type-iec-cdd>> shows an example from IEC CDD for a concept description of a _Property_ with usage of Level Type (in this example level type MIN, MAX and NOM, see data type).
-This is a short form of defining a collection of three properties with the same data type and semantics except for the level.
+The IRDI, the unique identifier of an IEC 61360 property or value, maps to _ConceptDescription/id_.
 
 .Example Property From ECLASS
 [[image-property-eclass]]
 image::image3.png[align=center]
+
+<<image-property-eclass>> to <<image-value-eclass-advanced>> show examples from ECLASS. <<image-property-value-list-eclass>> shows a property with enumeration type.
+One of the values in this enumeration is shown in <<image-value-eclass>>, each value has its own unique ID.
+The unique identifier of a value (<<image-value-eclass>>) is also used for _Property/valueId._
 
 .Example Property Description with Value List from ECLASS
 [[image-property-value-list-eclass]]
@@ -87,6 +84,9 @@ image::image5.png[align=center]
 .Example Value Description from ECLASS Advanced (Editor Modus)
 [[image-value-eclass-advanced]]
 image::image6.png[align=center]
+
+<<image-property-level-type-iec-cdd>> shows an example from IEC CDD for a concept description of a _Property_ with usage of Level Type (in this example level type MIN, MAX and NOM, see data type).
+This is a short form of defining a collection of three properties with the same data type and semantics except for the level.
 
 .Example for Property with Level Type from IEC CDD
 [[image-property-level-type-iec-cdd]]

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/introduction.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/introduction.adoc
@@ -46,6 +46,8 @@ The known data dictionaries ECLASS and IEC CDD are based on this standard.
 The data specification templates specified in this document make it possible to directly use concept descriptions as standardized in these data dictionaries.
 Additionally, concept descriptions, which do not (yet) exist in these data dictionaries, can be defined using the same schema.
 
+For guidance how to use ECLASS concept definitions in combination with the Asset Administration Shell including this data specification template see link:#bib28[[28\]].
+
 Concept descriptions, whether defined externally in existing data dictionaries or internally as part of the Asset Administration Shell environment, are the foundation for defining submodel templates link:#bib24[[24\]] link:#bib16[[16\]].
 
 IEC 61360-1:2017 is largely compliant to IEC 61360-2:2012 and ISO 3584-42:2010.

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/introduction.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/introduction.adoc
@@ -15,7 +15,7 @@ SPDX-License-Identifier: CC-BY-4.0
 This document is part of the series "Specification of the Asset Administration Shell" that provide the specifications for interoperable usage of the Asset Administration Shell.
 
 This part defines a technology-neutral specification of a data specification template, enabling the description of concept descriptions conformant to IEC 61360 in UML.
-This UML meta model serves as the basis for deriving several different formats for exchanging Asset Administration Shells, e.g. for XML, JSON, RDF as described in Part 1 of the document series (IDTA-01001).
+This UML metamodel serves as the basis for deriving several different formats for exchanging Asset Administration Shells, e.g. for XML, JSON, RDF as described in Part 1 of the document series (IDTA-01001).
 Data Specification Templates are implemented using the embedded data specification approach.
 This means, that the implementation is part of the overall schemas as defined for IDTA-01001.
 
@@ -28,10 +28,10 @@ image::image2.jpeg[align=center]
 
 File exchange (1) is described in Part 5 of this document series (IDTA-01005).
 
-The API (2) is specified in Part 2 of the document series "Specification of the Asset Administration Shell" (IDTA-01002) link:#bib14[[14\]].
+The API (2) is specified in Part 2 of the document series "Specification of the Asset Administration Shell" (IDTA-01002) link:bibliography.adoc#bib14[[14\]].
 It also includes access to concept descriptions using the data specifications as specified in this document.
 
-The I4.0 language (3) is based on the information metamodel specified in Part 1 and 3 link:#bib23[[23\]].
+The I4.0 language (3) is based on the information metamodel specified in Part 1 and 3 link:bibliography.adoc#bib23[[23\]].
 
 Part 3 is not a single document.
 Instead, it is an own series of documents, each featuring a specific use case that is supported by the specified data specification templates.
@@ -46,11 +46,11 @@ The known data dictionaries ECLASS and IEC CDD are based on this standard.
 The data specification templates specified in this document make it possible to directly use concept descriptions as standardized in these data dictionaries.
 Additionally, concept descriptions, which do not (yet) exist in these data dictionaries, can be defined using the same schema.
 
-For guidance how to use ECLASS concept definitions in combination with the Asset Administration Shell including this data specification template see link:#bib28[[28\]].
+For guidance how to use ECLASS concept definitions in combination with the Asset Administration Shell including this data specification template see link:bibliography.adoc#bib28[[28\]].
 
-Concept descriptions, whether defined externally in existing data dictionaries or internally as part of the Asset Administration Shell environment, are the foundation for defining submodel templates link:#bib24[[24\]] link:#bib16[[16\]].
+Concept descriptions, whether defined externally in existing data dictionaries or internally as part of the Asset Administration Shell environment, are the foundation for defining submodel templates link:bibliography.adoc#bib24[[24\]] link:bibliography.adoc#bib16[[16\]].
 
-IEC 61360-1:2017 is largely compliant to IEC 61360-2:2012 and ISO 3584-42:2010.
+IEC 61360-1:2017 is largely compliant to IEC 61360-2:2012 and ISO 13584-42:2010.
 
 ====
 Note: for details on how to use the data specifications and for further explanations, please refer directly to IEC 61360.
@@ -99,7 +99,7 @@ image::image7.png[align=center]
 
 === Overview
 
-A data specification template specifies which additional attributes shall be added to an element instance that are not part of the meta model.
+A data specification template specifies which additional attributes shall be added to an element instance that are not part of the metamodel.
 Typically, data specification templates have a specific scope.
 For example, templates for concept descriptions differ from templates for operations, etc.
 More than one data specification template can be defined and used for an element instance.

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/preamble.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/preamble.adoc
@@ -32,17 +32,21 @@ The reading guide gives advice on which documents should be read depending on th
 
 === Normative References
 
+[#IDTA-01001]
 [IDTA-01001] "Specification of the Asset Administration Shell.
 Part 1: Metamodel", IDTA-01001-3-1.
 Industrial Digital Twin Association.
 
+[#IEC61360-1]
 [IEC61360-1] Standard data element types with associated classification scheme – Part 1: Definitions – Principles and methods.
 Edition 4.0 2017-07
 
+[#IEC61360-2]
 [IEC61360-2] Standard data element types with associated classification scheme for electronic components.
 Part 2: EXPRESS dictionary schema.
 Edition 2012.
 
+[#IEC61360-2]
 [ISO 13584-42] ISO 13584-42:2010, "Industrial automation systems and integration – Parts library – Part 42: Description methodology: Methodology for structuring part families"
 
 === Structure of the Document

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/preamble.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/preamble.adoc
@@ -27,7 +27,7 @@ This document assumes familiarity with the concept and specification of the Asse
 The main stakeholders addressed in this document are architects and software developers aiming to implement a digital twin using the Asset Administration Shell in an interoperable way.
 Additionally, the content can also be used as input for discussions with international standardization organizations and further collaborations.
 
-Please consult the continuously updated reading guide link:#bib15[[15\]] for an overview of documents on the Asset Administration Shell.
+Please consult the continuously updated reading guide link:bibliography.adoc#bib15[[15\]] for an overview of documents on the Asset Administration Shell.
 The reading guide gives advice on which documents should be read depending on the role of the reader.
 
 === Normative References
@@ -46,7 +46,7 @@ Edition 4.0 2017-07
 Part 2: EXPRESS dictionary schema.
 Edition 2012.
 
-[#IEC61360-2]
+[#ISO-13584-42]
 [ISO 13584-42] ISO 13584-42:2010, "Industrial automation systems and integration – Parts library – Part 42: Description methodology: Methodology for structuring part families"
 
 === Structure of the Document

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/specification.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/specification.adoc
@@ -194,7 +194,7 @@ Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]],
 ====
 
 
-|xref:ValueFormatIec61360[ValueFormatIec61360] |0..1
+|xref:ValueFormatTypeIec61360[ValueFormatTypeIec61360] |0..1
 |valueList a|
 Enumerated list of allowed values
 
@@ -296,7 +296,7 @@ Note 1: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]
 
 
 ====
-Note 2: IEC61360 does not request to use more specific string types like TRANSLATBLE_STRING_TYPE, NON_TRANSLATABLE_STRING_TYPE, DATE_TIME_TYPE, DATE_TYPE, TIME_TYPE, IRDI_STRING, URI_TYPE, and HTML5_TYPE.
+Note 2: IEC61360 does not request to use more specific string types like TRANSLATABLE_STRING_TYPE, NON_TRANSLATABLE_STRING_TYPE, DATE_TIME_TYPE, DATE_TYPE, TIME_TYPE, IRDI_STRING, URI_TYPE, and HTML5_TYPE.
 It is requested to use the more specific data types in the AAS, if applicablefootnote:[This is also requested in ECLASS, see https://eclass.eu/support/technical-specification/structure-and-elements/value].
 ====
 
@@ -587,11 +587,11 @@ The data type of both Properties is the same.
 
 In the cases 2 and 4, the _semanticId_ of the Property or Properties within the _SubmodelElementCollection_ needs to include information about the level type.
 Otherwise, the semantics is not described in a unique way.
-In link:#bib27[[27\]], IRDI paths are introducedfootnote:[see also https://eclass.eu/support/technical-specification/data-model/irdi-path].
+In link:bibliography.adoc#bib27[[27\]], IRDI paths are introducedfootnote:[see also https://eclass.eu/support/technical-specification/data-model/irdi-path].
 
 It is not recommended to use level type when defining concept descriptions for Properties, except for ranges (i.e. min and max).
 This is considered to be a deprecated way of defining property sets.
-See also link:#bib27[[27\]], where one proposal on how to deal with level type is to remove the level type and to define several properties instead.
+See also link:bibliography.adoc#bib27[[27\]], where one proposal on how to deal with level type is to remove the level type and to define several properties instead.
 
 === Value List Attributes
 
@@ -985,7 +985,7 @@ Primitive data types start with a capital letter.
 [width="100%",cols="27%,31%,42%",options="header",]
 |===
 |*Primitive* |*Definition* |*Value Examples*
-|DefinitionTypeIec61360 a|
+|[[DefinitionTypeIec61360]]DefinitionTypeIec61360 a|
 _LangStringSet_
 
 Each langString within the array of strings has a length of maximum 1023 and a minimum of 1 characters.
@@ -1109,9 +1109,9 @@ _string_
 
 
 ====
-Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], value_format
+Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], value_format.
+The value format is based on ISO 13584-42 and IEC 61360-2.
 ====
-. The value format is based on ISO 13584-42 and IEC 61360-2.
 
 a|
 "NR3..3.3ES2"

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/specification.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/specification.adoc
@@ -667,7 +667,7 @@ _Mapped to MultiLanguageProperty, i.e. type MultiLanguageText_
 
 
 ====
-Note: for details, please see Part 1 of the document series "Details of the Asset Administration Shell".
+Note: for details, please see Part 1 of the document series "Specification of the Asset Administration Shell".
 ====
 
 
@@ -724,7 +724,7 @@ xs:string _or mapped to ReferenceElement_
 
 
 ====
-Note: for details, please see Part 1 of the document series "Details of the Asset Administration Shell".
+Note: for details, please see Part 1 of the document series "Specification of the Asset Administration Shell".
 ====
 
 
@@ -746,7 +746,7 @@ _Mapped to submodel element File, i.e. type PathType_
 
 
 ====
-Note: for details, please see Part 1 of the document series "Details of the Asset Administration Shell".
+Note: for details, please see Part 1 of the document series "Specification of the Asset Administration Shell".
 ====
 
 
@@ -756,7 +756,7 @@ _Mapped to submodel element Blob, i.e. type BlobType_
 
 
 ====
-Note: for details, please see Part 1 of the document series "Details of the Asset Administration Shell".
+Note: for details, please see Part 1 of the document series "Specification of the Asset Administration Shell".
 ====
 
 
@@ -766,7 +766,7 @@ _Mapped to submodel element Blob, i.e. type BlobType_
 
 
 ====
-Note: for details, please see Part 1 of the document series "Details of the Asset Administration Shell".
+Note: for details, please see Part 1 of the document series "Specification of the Asset Administration Shell".
 ====
 
 
@@ -919,19 +919,19 @@ Note: these constraints include elements of Part 1 Metamodel, IDTA-01001.
 {aasc3a004}
 
 ====
-Note: categories are deprecated since V3.0 of Part 1 of the document series "Details of the Asset Administration Shell".
+Note: categories are deprecated since V3.0 of Part 1 of the document series "Specification of the Asset Administration Shell".
 ====
 
 {aasc3a005}
 
 ====
-Note: categories are deprecated since V3.0 of Part 1 of the document series "Details of the Asset Administration Shell".
+Note: categories are deprecated since V3.0 of Part 1 of the document series "Specification of the Asset Administration Shell".
 ====
 
 {aasc3a006}
 
 ====
-Note: categories are deprecated since V3.0 of Part 1 of the document series "Details of the Asset Administration Shell".
+Note: categories are deprecated since V3.0 of Part 1 of the document series "Specification of the Asset Administration Shell".
 ====
 
 {aasc3a007}

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/specification.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/specification.adoc
@@ -567,7 +567,7 @@ h|Attribute h|Explanation h|Type h|Card.
 e|min a|Minimum of the value |boolean |1
 e|nom a|Nominal value (value as designated) |boolean |1
 e|typ a|Value as typically present |boolean |1
-e|max e|Maximum of the value |boolean |1
+e|max a|Maximum of the value |boolean |1
 |===
 
 ====

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/specification.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/specification.adoc
@@ -397,7 +397,7 @@ In the AAS, the values are TRUE (for "Yes") and FALSE (for "No").
 
 
 e|IRI a|
-values containing values of the type STRING conformant to Rfc 3987
+values containing values of the type STRING conformant to https://datatracker.ietf.org/doc/html/rfc3987[Rfc 3987]
 
 
 ====

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/specification.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/specification.adoc
@@ -297,7 +297,7 @@ Note 1: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]
 
 ====
 Note 2: IEC61360 does not request to use more specific string types like TRANSLATBLE_STRING_TYPE, NON_TRANSLATABLE_STRING_TYPE, DATE_TIME_TYPE, DATE_TYPE, TIME_TYPE, IRDI_STRING, URI_TYPE, and HTML5_TYPE.
-It is requested to use the more specific data types in the ASS, if applicablefootnote:[This is also requested in ECLASS, see https://eclass.eu/support/technical-specification/structure-and-elements/value].
+It is requested to use the more specific data types in the AAS, if applicablefootnote:[This is also requested in ECLASS, see https://eclass.eu/support/technical-specification/structure-and-elements/value].
 ====
 
 
@@ -332,7 +332,7 @@ For more specific data types, INTEGER_MEASURE_TYPE or INTEGER_CURRENCY_TYPE may 
 
 
 ====
-Note 2: it is requested to use the more specific data types in the ASS, if applicable.
+Note 2: it is requested to use the more specific data types in the AAS, if applicable.
 ====
 
 

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/specification.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/specification.adoc
@@ -649,12 +649,17 @@ Examples for the different IEC 61360 data types can be found here: https://eclas
 .Mapping IEC 61360 Data Types to xsd Data Types
 [width="100%",cols="31%,30%,39%",options="header",]
 |===
-|*Data Type IEC 61360* |*xsd Value Type*footnote:[_Property/valueType_, _Range/valueType,_ etc. are each of type _DataTypeDefXsd._
+h|Data Type IEC 61360 
+h|xsd Value Typefootnote:[_Property/valueType_, _Range/valueType,_ etc. are each of type _DataTypeDefXsd._
 
-====
-Note: for submodel elements like _Blob_ and _File_ or _MultiLanguageProperty and ReferenceElement,_ there is no explicitly defined _valueType_ attribute because the data type is implicitly defined and fix (_BlobType_, _PathType_ or _MultiLanguageTextType, Reference_).] |*Example Values IEC 61360*footnote:[Source for most examples for the different IEC 61360 data types: https://eclass.eu/support/technical-specification/structure-and-elements/value.
+Note: for submodel elements like _Blob_ and _File_ or _MultiLanguageProperty and ReferenceElement,_ there is no explicitly defined _valueType_ attribute 
+because the data type is implicitly defined and fix (_BlobType_, _PathType_ or _MultiLanguageTextType, Reference_).
+
+]
+
+h|Example Values IEC 61360footnote:[Source for most examples for the different IEC 61360 data types: https://eclass.eu/support/technical-specification/structure-and-elements/value.
 The IRDI example for STRING was moved to IRDI.]
-====
+
 
 |DATE |xs:date |1979-01-15
 |STRING |xs:string a|

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/specification.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/specification.adoc
@@ -41,11 +41,11 @@ h|*id:* 3+a|`\https://admin-shell.io/DataSpecificationTemplates/DataSpecificatio
 `\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIEC61360/3/0`
 
 
-h|*dataSpecificationContent:* |DataSpecificationIec61360 | |
+h|*dataSpecificationContent:* 3+|DataSpecificationIec61360 
 h|*Description (EN):* 3+a|Data specification template for concept descriptions for properties and values conformant to IEC 61360.
 |===
 
-The ID of the data specification template was derived conformant to the rules for semantic IDs for data specifications as defined in Part 1 of the document series, IDTA-01001-3-1.
+The ID of the data specification template was derived conformant to the rules for semantic IDs for data specifications as defined in Part 1 of the document series, IDTA-01001.
 
 This ID will be used in _hasDataSpecification/dataSpecification_.
 
@@ -68,7 +68,7 @@ Content of data specification template for concept descriptions for properties, 
 
 
 ====
-Note: for details, please refer to [IEC61360-1], property, value_list and term
+Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], property, value_list and term
 ====
 
 {aasc3a010}
@@ -95,28 +95,28 @@ Preferred name in different languages
 
 
 ====
-Note: for details, please refer to [IEC61360-1], preferred_name
+Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], preferred_name
 ====
 
 {aasc3a002}
 
-|PreferredNameTypeIec61360 |1
+|xref:PreferredNameTypeIec61360[PreferredNameTypeIec61360] |1
 |shortName a|
 Short name
 
 
 ====
-Note: for details, please refer to [IEC61360-1], short_name
+Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], short_name
 ====
 
 
-|ShortNameTypeIec61360 |0..1
+|xref:ShortNameTypeIec61360[ShortNameTypeIec61360] |0..1
 |unit a|
 Unit in case of a quantitative property
 
 
 ====
-Note 1: for details, please refer to [IEC61360-1], unit_in_text
+Note 1: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], unit_in_text
 ====
 
 
@@ -134,7 +134,7 @@ Unit and unitId need to be consistent if both attributes are set
 
 
 ====
-Note 1: for details, please refer to [IEC61360-1], unit_of_measure
+Note 1: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], unit_of_measure
 ====
 
 
@@ -150,7 +150,7 @@ Source of definition
 
 
 ====
-Note: for details, please refer to [IEC61360-1], source_document_of_definition
+Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], source_document_of_definition
 ====
 
 
@@ -160,7 +160,7 @@ Symbol
 
 
 ====
-Note: for details, please refer to [IEC61360-1], preferred_letter_symbol
+Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], preferred_letter_symbol
 ====
 
 
@@ -170,37 +170,37 @@ Data Type
 
 
 ====
-Note: for details, please refer to [IEC61360-1], data_type
+Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], data_type
 ====
 
 
-|DataTypeIec61360 |0..1
+|xref:DataTypeIec61360[DataTypeIec61360] |0..1
 |definition a|
 Definition in different languages
 
 
 ====
-Note: for details, please refer to [IEC61360-1], definition
+Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], definition
 ====
 
 
-|DefinitionTypeIec61360 |0..1
+|xref:DefinitionTypeIec61360[DefinitionTypeIec61360] |0..1
 |valueFormat a|
 Value Format
 
 
 ====
-Note: for details, please refer to [IEC61360-1], value_format
+Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], value_format
 ====
 
 
-|ValueFormatIec61360 |0..1
+|xref:ValueFormatIec61360[ValueFormatIec61360] |0..1
 |valueList a|
 Enumerated list of allowed values
 
 
 ====
-Note 1: for details, please refer to [IEC61360-1], enumerated_list_of_terms.
+Note 1: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], enumerated_list_of_terms.
 ====
 
 
@@ -210,27 +210,27 @@ Note 2: for ease of usage, the value list is modelled as value/valueId list in t
 ====
 
 
-|ValueList |0..1
+|xref:ValueList[ValueList] |0..1
 |value a|
 Value (typically within a value list)
 
 
 ====
-Note: for details, please refer to [IEC61360-1], term/preferred_letter_symbol_in_text
+Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], term/preferred_letter_symbol_in_text
 ====
 
 
-|ValueTypeIec61360 |0..1
+|xref:ValueTypeIec61360[ValueTypeIec61360] |0..1
 |levelType a|
 Value represented by up to four variants of a numeric value in a specific role: MIN, NOM, TYP and MAX.
 
 
 ====
-Note: for details, please refer to [IEC61360-1], LEVEL_TYPE
+Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], LEVEL_TYPE
 ====
 
 
-|LevelType |0..1
+|xref:LevelType[LevelType] |0..1
 |===
 
 {empty}
@@ -268,7 +268,7 @@ image::image10.png[align=center]
 
 [width="100%",cols="30%,70%",]
 |===
-h|Enumeration: |DataTypeIec61360
+h|Enumeration: |[[DataTypeIec61360]]DataTypeIec61360
 h|Explanation: |Enumeration of simple data types for an IEC 61360 concept description using the data specification template _DataSpecificationIec61360_
 h|Set of: |--
 h|Literal h|Explanation
@@ -279,7 +279,7 @@ Format yyyy-mm-dd
 
 
 ====
-Note: for details, please refer to [IEC61360-1], specific STRING_TYPE, the DATE_TYPE.
+Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], specific STRING_TYPE, the DATE_TYPE.
 ====
 
 
@@ -290,7 +290,7 @@ values consisting of a sequence of characters, which cannot be translated into o
 
 
 ====
-Note 1: for details, please refer to [IEC61360-1], specific STRING_TYPE, the NON_TRANSLATABLE_STRING_TYPE.
+Note 1: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], specific STRING_TYPE, the NON_TRANSLATABLE_STRING_TYPE.
 ====
 
 
@@ -306,7 +306,7 @@ values containing string, but which shall be represented as different strings in
 
 
 ====
-Note: for details, please refer to [IEC61360-1], specific STRING_TYPE, the TRANSLATABLE_STRING_TYPE
+Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], specific STRING_TYPE, the TRANSLATABLE_STRING_TYPE
 ====
 
 
@@ -316,7 +316,7 @@ In addition, such a value comes with a physical unit.
 
 
 ====
-Note: for details, please refer to [IEC61360-1], specific INTEGER (or INT_TYPE) NUMBER_TYPE, the INT_MEASURE_TYPE
+Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], specific INTEGER (or INT_TYPE) NUMBER_TYPE, the INT_MEASURE_TYPE
 ====
 
 
@@ -325,7 +325,7 @@ values containing values of the type INTEGER, but which are no currencies or mea
 
 
 ====
-Note 1: for details, please refer to [IEC61360-1], specific NUMBER_TYPE, the INT_TYPE (or just INTEGER).
+Note 1: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], specific NUMBER_TYPE, the INT_TYPE (or just INTEGER).
 For more specific data types, INTEGER_MEASURE_TYPE or INTEGER_CURRENCY_TYPE may be used.
 ====
 
@@ -341,7 +341,7 @@ values containing values of the type INTEGER, which are currencies
 
 
 ====
-Note: for details, please refer to [IEC61360-1], specific INTEGER NUMBER_TYPE, the INT_CURRENCY_TYPE
+Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], specific INTEGER NUMBER_TYPE, the INT_CURRENCY_TYPE
 ====
 
 
@@ -351,7 +351,7 @@ In addition, such a value comes with a physical unit.
 
 
 ====
-Note: for details, please refer to [IEC61360-1], specific REAL NUMBER_TYPE, the REAL_MEASURE_TYPE
+Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], specific REAL NUMBER_TYPE, the REAL_MEASURE_TYPE
 ====
 
 
@@ -360,7 +360,7 @@ values containing numbers that can be written as a terminating or non-terminatin
 
 
 ====
-Note 1: for details, please refer to [IEC61360-1], specific NUMBER_TYPE, the REAL_TYPE.
+Note 1: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], specific NUMBER_TYPE, the REAL_TYPE.
 For more specific data types REAL_MEASURE_TYPE or REAL_CURRENCY_TYPE may be used.
 ====
 
@@ -376,7 +376,7 @@ values containing values of the type REAL, which are currencies
 
 
 ====
-Note: for details, please refer to [IEC61360-1], specific REAL NUMBER_TYPE, the REAL_CURRENCY_TYPE
+Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], specific REAL NUMBER_TYPE, the REAL_CURRENCY_TYPE
 ====
 
 
@@ -385,7 +385,7 @@ values representing truth of logic or Boolean algebra (TRUE, FALSE)
 
 
 ====
-Note 1: for details, please refer to [IEC61360-1], BOOLEAN_TYPE.
+Note 1: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], BOOLEAN_TYPE.
 ====
 
 
@@ -401,7 +401,7 @@ values containing values of the type STRING conformant to Rfc 3987
 
 
 ====
-Note 1: for details, please refer to [IEC61360-1], specific STRING_TYPE, the URI_TYPE.
+Note 1: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], specific STRING_TYPE, the URI_TYPE.
 ====
 
 
@@ -418,7 +418,7 @@ values conforming to ISO/IEC 11179 series global identifier sequences
 
 
 ====
-Note 1: for details, please refer to [IEC61360-1], specific STRING_TYPE, the IRDI_STRING.
+Note 1: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], specific STRING_TYPE, the IRDI_STRING.
 ====
 
 
@@ -449,7 +449,7 @@ Examples: ½, ¾ or 7/2
 
 
 ====
-Note 1: for details, please refer to [IEC61360-1], specific NUMBER_TYPE, the RATIONAL_TYPE.
+Note 1: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], specific NUMBER_TYPE, the RATIONAL_TYPE.
 ====
 
 
@@ -465,7 +465,7 @@ In addition, such a value comes with a physical unit.
 
 
 ====
-Note: for details, please refer to [IEC61360-1], specific RATIONAL NUMBER_TYPE, the RATIONAL_MEASURE_TYPE
+Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], specific RATIONAL NUMBER_TYPE, the RATIONAL_MEASURE_TYPE
 ====
 
 
@@ -478,7 +478,7 @@ Example from IEC 61360-1:2017: "13:20:00-05:00" is the [TIME] representation of:
 
 
 ====
-Note: for details, please refer to [IEC61360-1], specific STRING_TYPE, the TIME_TYPE
+Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], specific STRING_TYPE, the TIME_TYPE
 ====
 
 
@@ -489,7 +489,7 @@ Format yyyy-mm-dd hh:mm (ECLASS)
 
 
 ====
-Note: for details, please refer to [IEC61360-1], specific STRING_TYPE, the DATE_TIME_TYPE.
+Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], specific STRING_TYPE, the DATE_TIME_TYPE.
 ====
 
 
@@ -499,7 +499,7 @@ The values are of the type URI and can represent an absolute or relative path.
 
 
 ====
-Note: [IEC61360-1] does not explicitly support the file type.
+Note: xref:preamble.adoc#IEC61360-1[[IEC61360-1\]] does not explicitly support the file type.
 It would map to the URI_TYPE.
 ====
 
@@ -509,7 +509,7 @@ Values containing string with any sequence of characters, using the syntax of HT
 
 
 ====
-Note: for details, please refer to [IEC61360-1], specific STRING_TYPE, the HTML5_TYPE.
+Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], specific STRING_TYPE, the HTML5_TYPE.
 ====
 
 
@@ -525,7 +525,7 @@ However, a blob may also contain other source code.
 
 
 ====
-Note: for details, please refer to [IEC61360-1], BINARY_TYPE
+Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], BINARY_TYPE
 ====
 
 
@@ -542,20 +542,20 @@ image::image11.png[align=center]
 
 [width="100%",cols="20%,47%,24%,9%]
 |===
-h|Class: 3+e|LevelType
+h|Class: 3+e|[[LevelType]]LevelType
 h|Explanation: 3+a|
 Value represented by up to four variants of a numeric value in a specific role: MIN, NOM, TYP, and MAX.
 True means that the value is available, false means the value is not available.
 
 
 ====
-Note: for details, please refer to [IEC61360-1], LEVEL_TYPE
+Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], LEVEL_TYPE
 ====
 
 
-EXAMPLE from [IEC61360-1]: in case of a property which is of the LEVEL_TYPE min/max −
+EXAMPLE from xref:preamble.adoc#IEC61360-1[[IEC61360-1\]]: in case of a property which is of the LEVEL_TYPE min/max −
 ====
-Note: for details, please refer to [IEC61360-1], LEVEL_TYPE
+Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], LEVEL_TYPE
 ====
 
 
@@ -603,30 +603,30 @@ image::image12.png[align=center]
 
 [width="100%",cols="22%,44%,23%,11%"]
 |===
-h|Class: 3+e|ValueList
+h|Class: 3+e|[[ValueList]]ValueList
 h|Explanation: 3+a|
 A set of value reference pairs
 
 
 ====
-Note: for details, please refer to [IEC61360-1], value_list/enumerated_list_of_terms.
+Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], value_list/enumerated_list_of_terms.
 ====
 
 
 h|Inherits from: 3+|--
 h|Attribute h|Explanation h|Type h|Card.
-e|valueReferencePair |A pair of a value together with its global unique ID. |ValueReferencePair |1..*
+e|valueReferencePair |A pair of a value together with its global unique ID. |xref:ValueReferencePair[ValueReferencePair] |1..*
 |===
 
 {empty}
 
 [width="100%",cols="24%,42%,23%,11%"]
 |===
-h|Class: 3+e|ValueReferencePair
+h|Class: 3+e|[[ValueReferencePair]]ValueReferencePair
 h|Explanation: |A value reference pair within a value list. Each value has a global unique ID defining its semantic. | |
 h|Inherits from: |-- | |
 h|Attribute h|Explanation h|Type h|Card.
-e|value |the value of the referenced concept definition of the value in _valueId._ |ValueTypeIec61360 |1
+e|value |the value of the referenced concept definition of the value in _valueId._ |xref:ValueTypeIec61360[ValueTypeIec61360] |1
 e|valueId a|
 Global unique ID of the value
 
@@ -983,14 +983,14 @@ Primitive data types start with a capital letter.
 |DefinitionTypeIec61360 a|
 _LangStringSet_
 
-Each langString within the array of strings has a length of maximum 1,023 and a minimum of 1 characters.
+Each langString within the array of strings has a length of maximum 1023 and a minimum of 1 characters.
 
 a|
 "Greatest permissible rotation speed with which the motor or feeding unit may be operated."
 
 
 ====
-Note: see xref:introduction.adoc#image-property-eclass[Figure]
+Note: see xref:introduction.adoc#image-property-eclass[Figure 2. Example Property from ECLASS]
 ====
 
 
@@ -1009,11 +1009,11 @@ Note 2: a langString is a string value tagged with a language code.
 ====
 
 
-The realization of a technology depend on the serialization rules.
+The realization of a langString depends on the serialization rules for a technology.
 
 
 ====
-Note: as defined in Part 1 Metamode, IDTA-01001.
+Note: as defined in Part 1 Metamodel, IDTA-01001.
 ====
 
 
@@ -1055,7 +1055,7 @@ In JSON:
 ]
 ----
 
-|PreferredNameTypeIec61360 a|
+|[[PreferredNameTypeIec61360]]PreferredNameTypeIec61360 a|
 _LangStringSet_
 
 Each _string_ with a length of maximum 255 and minimum of 1 characters.
@@ -1068,7 +1068,7 @@ Note 1: it is advised to keep the length of the name limited to 35 characters.
 
 
 ====
-Note 2: for details, please refer to [IEC61360-1], preferred_name
+Note 2: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], preferred_name
 ====
 
 
@@ -1076,17 +1076,17 @@ a|
 "max. rotation speed"@EN
 
 ====
-Note: see xref:introduction.adoc#image-property-eclass[Figure]
+Note: see xref:introduction.adoc#image-property-eclass[Figure 2. Example Property from ECLASS]
 ====
 
-|ShortNameTypeIec61360 a|
+|[[ShortNameTypeIec61360]]ShortNameTypeIec61360 a|
 _LangStringSet_
 
 Each _string_ with a length of maximum 18 and a minimum of 1 characters.
 
 
 ====
-Note: for details, please refer to [IEC61360-1], short_name
+Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], short_name
 ====
 
 
@@ -1095,16 +1095,16 @@ a|
 
 
 ====
-Note: See xref:introduction.adoc#image-property-level-type-iec-cdd[Figure]
+Note: See xref:introduction.adoc#image-property-level-type-iec-cdd[Figure 6. Example for Property with Level Type from IEC CDD]
 ====
 
 
-|ValueFormatTypeIec61360 a|
+|[[ValueFormatTypeIec61360]]ValueFormatTypeIec61360 a|
 _string_
 
 
 ====
-Note: for details, please refer to [IEC61360-1], value_format
+Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], value_format
 ====
 . The value format is based on ISO 13584-42 and IEC 61360-2.
 
@@ -1113,11 +1113,11 @@ a|
 
 
 ====
-Note: See xref:introduction.adoc#image-property-level-type-iec-cdd[Figure]
+Note: See xref:introduction.adoc#image-property-level-type-iec-cdd[https://portal.bosch.com/]
 ====
 
 
-|ValueTypeIec61360 |_string_ with a length of maximum 2048 and minimum of 1 characters. a|
+|[[ValueTypeIec61360]]ValueTypeIec61360 |_string_ with a length of maximum 2048 and minimum of 1 characters. a|
 "Blue"
 
 "1000"

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/specification.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/specification.adoc
@@ -553,7 +553,7 @@ Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]],
 ====
 
 
-EXAMPLE from xref:preamble.adoc#IEC61360-1[[IEC61360-1\]]: in case of a property which is of the LEVEL_TYPE min/max −
+
 ====
 Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], LEVEL_TYPE
 ====

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/summary-and-outlook.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/summary-and-outlook.adoc
@@ -15,7 +15,7 @@ These data specification templates are conformant to IEC 61360.
 
 This document is part of the document series "Specification of the Asset Administration Shell".
 
-Additional parts of the document series cover (see link:#bib14[[14\]]):
+Additional parts of the document series cover (see link:bibliography.adoc#bib14[[14\]]):
 
 * the information model that is the basis for file exchange and interface payload definition (IDTA-01001, Part 1),
 * interfaces and APIs for accessing the information of Asset Administration Shells (access, modify, query, and execute information and active functionality) (IDTA-01002, Part 2),

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/terms-definitions-and-abbreviations.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/terms-definitions-and-abbreviations.adoc
@@ -70,6 +70,14 @@ Note 3 to entry: the impact manifests itself in a measurable effect within the p
 
 _[SOURCE: Glossary Industrie 4.0, minor changes]_
 
+
+*coded value*::
+
+value that can be looked up in a dictionary and can be translated
+
+_[SOURCE: link:https://eclass.eu/support/technical-specification/data-model/conceptual-data-model[ECLASS] footnote:[In IEC61360:2017, this refers to a "term" of a value list]]_
+
+
 *identifier (ID)*::
 
 identity information that unambiguously distinguishes one entity from another one in a given domain

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/terms-definitions-and-abbreviations.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/terms-definitions-and-abbreviations.adoc
@@ -189,11 +189,6 @@ element of a _Submodel_
 
 _[SOURCE: IEC 63278-1:2023]_
 
-*SubmodelElement*::
-
-element of a _Submodel_
-
-_[SOURCE: IEC 63278-1:2023]_
 
 ==  Abbreviations Used in Document
 

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/terms-definitions-and-abbreviations.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/terms-definitions-and-abbreviations.adoc
@@ -18,7 +18,7 @@ SPDX-License-Identifier: CC-BY-4.0
 This glossary applies only within the context of this document.
 ====
 
-If available, definitions were taken from IEC 63278-1 Edition 1.0 2023-12.
+If available, definitions were taken from IEC 63278-1 Edition 1.0 2023-12 or IEC 61360-1 Edition 4.0 2017-07.
 
 *application*::
 
@@ -93,7 +93,7 @@ Note 1 to entry: additional information about the nature of the value can be obt
 _Property_ information object to which the value belongs.
 ====
 
-_[SOURCE:IEC 61360-1_2017]_
+_[SOURCE: IEC 61360-1:2017]_
 
 *maximum value*::
 
@@ -108,7 +108,7 @@ Note 1 to entry: additional information about the nature of the value can be obt
 _Property_ information object to which the value belongs.
 ====
 
-_[SOURCE:IEC 61360-1_2017]_
+_[SOURCE: IEC 61360-1:2017]_
 
 *nominal value*::
 
@@ -119,7 +119,7 @@ Note 1 to entry: additional information about the nature of the value can be obt
 _Property_ information object to which the value belongs.
 ====
 
-_[SOURCE:IEC 61360-1_2017]_
+_[SOURCE: IEC 61360-1:2017]_
 
 *non-quantitative property*::
 
@@ -175,7 +175,7 @@ _[SOURCE: according to ISO/IEC Guide 77-2] as well as [SOURCE: according to Glos
 
 property with a numerical value representing a physical quantity, a quantity of information or a count of objects
 
-_[SOURCE: IEC 61360-1_2017 – based on IEC 61360-2:2012, 3.40, modified – "data element type" is replaced by "property"]_
+_[SOURCE: IEC 61360-1:2017 – based on IEC 61360-2:2012, 3.40, modified – "data element type" is replaced by "property"]_
 
 *Submodel*::
 
@@ -197,13 +197,10 @@ _[SOURCE: IEC 63278-1:2023]_
 |*Abbreviation* |*Description*
 |AAS |Asset Administration Shell
 |AASX |Package file format for the Asset Administration Shell
-|AML |AutomationML
 |API |Application Programming Interface
-|BITKOM |Bundesverband Informationswirtschaft, Telekommunikation und neue Medien e. V.
 |BLOB |Binary Large Object
 |CDD |Common Data Dictionary
 |GUID |Globally unique identifier
-|I4.0 |Industrie 4.0
 |ID |Identifier
 |IDTA |Industrial Digital Twin Association
 |IEC |International Electrotechnical Commission
@@ -212,15 +209,9 @@ _[SOURCE: IEC 63278-1:2023]_
 |ISO |International Organization for Standardization
 |JSON |JavaScript Object Notation
 |MIME |Multipurpose Internet Mail Extensions
-|OPC |Open Packaging Conventions (ECMA-376, ISO/IEC 29500-2)
-|OPCF |OPC Foundation
-|OPC UA |OPC Unified Architecture
 |PDF |Portable Document Format
-|RAMI4.0 |Reference Architecture Model Industrie 4.0
 |RDF |Resource Description Framework
-|REST |Representational State Transfer
 |RFC |Request for Comment
-|SOA |Service Oriented Architecture
 |UML |Unified Modelling Language
 |URI |Uniform Resource Identifier
 |URL |Uniform Resource Locator


### PR DESCRIPTION
 editorial changes including
- add links to attribute types etc.
- remove unused bib items (but bib items not yet renumbered)
- add links to Rfc
- removing unclear examples
- add new term "coded value"
- add that IEC 63278-1 and IEC 61360-1:2017 both are preferred to be used for terms and definitions
- add new bib item for How to transport ECLASS to AAS and mention it