### PR TITLE
Remove variable for classes in PUML files

### DIFF
--- a/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/concept-description-categories.puml
+++ b/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/concept-description-categories.puml
@@ -1,5 +1,3 @@
 @startuml
-!$classes = "https://raw.githubusercontent.com/admin-shell-io/aas-specs-iec61360/IDTA-01003-a-3-1_working/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes"
-
-!include $classes/enum-concept-description-categories.puml
+!include https://raw.githubusercontent.com/admin-shell-io/aas-specs-iec61360/IDTA-01003-a-3-1_working/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes/enum-concept-description-categories.puml
 @enduml

--- a/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/data-element.puml
+++ b/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/data-element.puml
@@ -1,13 +1,11 @@
 @startuml
-!$classes = "https://raw.githubusercontent.com/admin-shell-io/aas-specs-iec61360/IDTA-01003-a-3-1_working/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes"
-
-!include $classes/data-element.puml
-!include $classes/property.puml
-!include $classes/multi-language-property.puml
-!include $classes/range.puml
-!include $classes/blob.puml
-!include $classes/file.puml
-!include $classes/reference-element.puml
+!include https://raw.githubusercontent.com/admin-shell-io/aas-specs-iec61360/IDTA-01003-a-3-1_working/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes/data-element.puml
+!include https://raw.githubusercontent.com/admin-shell-io/aas-specs-iec61360/IDTA-01003-a-3-1_working/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes/property.puml
+!include https://raw.githubusercontent.com/admin-shell-io/aas-specs-iec61360/IDTA-01003-a-3-1_working/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes/multi-language-property.puml
+!include https://raw.githubusercontent.com/admin-shell-io/aas-specs-iec61360/IDTA-01003-a-3-1_working/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes/range.puml
+!include https://raw.githubusercontent.com/admin-shell-io/aas-specs-iec61360/IDTA-01003-a-3-1_working/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes/blob.puml
+!include https://raw.githubusercontent.com/admin-shell-io/aas-specs-iec61360/IDTA-01003-a-3-1_working/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes/file.puml
+!include https://raw.githubusercontent.com/admin-shell-io/aas-specs-iec61360/IDTA-01003-a-3-1_working/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes/reference-element.puml
 
 DataElement <|--- Blob
 DataElement <|--- File

--- a/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/dataspec-iec61360.puml
+++ b/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/dataspec-iec61360.puml
@@ -1,10 +1,8 @@
 @startuml
-!$classes = "https://raw.githubusercontent.com/admin-shell-io/aas-specs-iec61360/IDTA-01003-a-3-1_working/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes"
-
-!include $classes/data-specification-iec61360.puml
-!include $classes/level-type.puml
-!include $classes/value-reference-pair.puml
-!include $classes/enum-datatype-iec61360.puml
+!include https://raw.githubusercontent.com/admin-shell-io/aas-specs-iec61360/IDTA-01003-a-3-1_working/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes/data-specification-iec61360.puml
+!include https://raw.githubusercontent.com/admin-shell-io/aas-specs-iec61360/IDTA-01003-a-3-1_working/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes/level-type.puml
+!include https://raw.githubusercontent.com/admin-shell-io/aas-specs-iec61360/IDTA-01003-a-3-1_working/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes/value-reference-pair.puml
+!include https://raw.githubusercontent.com/admin-shell-io/aas-specs-iec61360/IDTA-01003-a-3-1_working/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes/enum-datatype-iec61360.puml
 
 DataSpecificationIec61360 ..> ValueList
 DataSpecificationIec61360 ..> LevelType

--- a/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/datatype-iec61360.puml
+++ b/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/datatype-iec61360.puml
@@ -1,5 +1,3 @@
 @startuml
-!$classes = "https://raw.githubusercontent.com/admin-shell-io/aas-specs-iec61360/IDTA-01003-a-3-1_working/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes"
-
-!include $classes/enum-datatype-iec61360.puml
+!include https://raw.githubusercontent.com/admin-shell-io/aas-specs-iec61360/IDTA-01003-a-3-1_working/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes/enum-datatype-iec61360.puml
 @enduml

--- a/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/has-semantics.puml
+++ b/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/has-semantics.puml
@@ -1,5 +1,3 @@
 @startuml
-!$classes = "https://raw.githubusercontent.com/admin-shell-io/aas-specs-iec61360/IDTA-01003-a-3-1_working/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes"
-
-!include $classes/has-semantics.puml
+!include https://raw.githubusercontent.com/admin-shell-io/aas-specs-iec61360/IDTA-01003-a-3-1_working/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes/has-semantics.puml
 @enduml

--- a/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/level-type.puml
+++ b/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/level-type.puml
@@ -1,5 +1,3 @@
 @startuml
-!$classes = "https://raw.githubusercontent.com/admin-shell-io/aas-specs-iec61360/IDTA-01003-a-3-1_working/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes"
-
-!include $classes/level-type.puml
+!include https://raw.githubusercontent.com/admin-shell-io/aas-specs-iec61360/IDTA-01003-a-3-1_working/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes/level-type.puml
 @enduml

--- a/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/reference-metamodel.puml
+++ b/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/reference-metamodel.puml
@@ -1,10 +1,8 @@
 @startuml
-!$classes = "https://raw.githubusercontent.com/admin-shell-io/aas-specs-iec61360/IDTA-01003-a-3-1_working/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes"
-
-!include $classes/key.puml
-!include $classes/reference.puml
-!include $classes/enum-reference-types.puml
-!include $classes/enum-key-types.puml
+!include https://raw.githubusercontent.com/admin-shell-io/aas-specs-iec61360/IDTA-01003-a-3-1_working/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes/key.puml
+!include https://raw.githubusercontent.com/admin-shell-io/aas-specs-iec61360/IDTA-01003-a-3-1_working/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes/reference.puml
+!include https://raw.githubusercontent.com/admin-shell-io/aas-specs-iec61360/IDTA-01003-a-3-1_working/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes/enum-reference-types.puml
+!include https://raw.githubusercontent.com/admin-shell-io/aas-specs-iec61360/IDTA-01003-a-3-1_working/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes/enum-key-types.puml
 
 Reference .> ReferenceTypes
 Reference ..> Key

--- a/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/rel-metamodel-iec61360.puml
+++ b/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/rel-metamodel-iec61360.puml
@@ -1,17 +1,15 @@
 @startuml
-!$classes = "https://raw.githubusercontent.com/admin-shell-io/aas-specs-iec61360/IDTA-01003-a-3-1_working/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes"
-
 skinparam packageStyle rectangle
 
 package "Data Specification Templates - Part 1"  {
-    !include $classes/data-specification-template.puml
-    !include $classes/data-specification-content.puml
+    !include https://raw.githubusercontent.com/admin-shell-io/aas-specs-iec61360/IDTA-01003-a-3-1_working/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes/data-specification-template.puml
+    !include https://raw.githubusercontent.com/admin-shell-io/aas-specs-iec61360/IDTA-01003-a-3-1_working/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes/data-specification-content.puml
 }
 
-!include $classes/data-specification-iec61360.puml
+!include https://raw.githubusercontent.com/admin-shell-io/aas-specs-iec61360/IDTA-01003-a-3-1_working/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes/data-specification-iec61360.puml
 
 package "Concept Descriptions - Part 1"  {
-    !include $classes/concept-description.puml
+    !include https://raw.githubusercontent.com/admin-shell-io/aas-specs-iec61360/IDTA-01003-a-3-1_working/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes/concept-description.puml
 }
 
 DataSpecificationContent <|- DataSpecificationIec61360

--- a/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/value-list.puml
+++ b/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/value-list.puml
@@ -1,6 +1,4 @@
 @startuml
-!$classes = "https://raw.githubusercontent.com/admin-shell-io/aas-specs-iec61360/IDTA-01003-a-3-1_working/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes"
-
-!include $classes/value-reference-pair.puml
+!include https://raw.githubusercontent.com/admin-shell-io/aas-specs-iec61360/IDTA-01003-a-3-1_working/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes/value-reference-pair.puml
 ValueList *-- "1..*" ValueReferencePair
 @enduml


### PR DESCRIPTION
The PUML preprocessor in Antora could not handle varibales, so incorrect diagramms were generated. 

In this PR we removed variables from PUMLs and use everywhere links instead.

See how diagramms look after fix: https://rwth-iat.github.io/aas-specs-antora/IDTA-01003-a/v3.1/introduction.html