### PR TITLE
Changes

### DIFF
--- a/documentation/IDTA-01003-a/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/changelog.adoc
@@ -42,7 +42,9 @@ Major changes:
 * Transfer of all UML figures to PlantUML (.puml) and maintenance in GitHub, no XMI presenation part of release any longer (https://github.com/admin-shell-io/aas-specs/issues/34[#34])
 
 * Update Terms and Definitions to be compliant to IEC63278-1:2023 and other parts of specification 
+	- (Removed) application
 	- (Update Source) Asset Administration Shell
+	- (Removed) capability
 	- (Removed) class
 	- (New) coded value (from Part 1)
 	- (Removed) concept

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/changelog.adoc
@@ -36,6 +36,8 @@ Major changes:
 * CHANGE ValueReferencePair/valueId now optional (https://github.com/admin-shell-io/aas-specs/issues/28[#28])
 * Update all metamodel element IDs to V3.1 (https://github.com/admin-shell-io/aas-specs/issues/17[#17])
 
+* remove recommendation to use external references for semantic identifiers, i.e. for _valueId_ and _unitId_ (https://github.com/admin-shell-io/aas-specs/issues/376[#376 of IDTA-01001]) 
+
 * Transfer from .docx to asciidoc
 * Transfer of all UML figures to PlantUML (.puml) and maintenance in GitHub, no XMI presenation part of release any longer (https://github.com/admin-shell-io/aas-specs/issues/34[#34])
 

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/changelog.adoc
@@ -61,6 +61,8 @@ Minor changes:
 
 * added note: This specification is only valid in combination with IDTA-01001-3-1.
 
+* updated bibliography
+
 * editorial (including (https://github.com/admin-shell-io/aas-specs-iec61360/issues/10[#10], https://github.com/admin-shell-io/aas-specs-iec61360/issues/3[#3])
 
 .Changes in Metamodel V3.1

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/changelog.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/changelog.adoc
@@ -63,6 +63,8 @@ Minor changes:
 
 * updated bibliography
 
+* removed Subclause "Working Principles"
+
 * editorial (including (https://github.com/admin-shell-io/aas-specs-iec61360/issues/10[#10], https://github.com/admin-shell-io/aas-specs-iec61360/issues/3[#3])
 
 .Changes in Metamodel V3.1

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/includes/constraints.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/includes/constraints.adoc
@@ -12,7 +12,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 :aasc3a002: pass:q[[underline]#Constraint AASc-3a-002:# _DataSpecificationIec61360/preferredName_ shall be provided at least in English.]
 
-:aasc3a003: pass:q[[underline]#Constraint AASc-3a-002:#For a _ConceptDescription_ referenced via _ValueList/valueId_ and using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3), _DataSpecificationIec61360/value_ shall be set.]
+:aasc3a003: pass:q[[underline]#Constraint AASc-3a-003:# For a _ConceptDescription_ referenced via _ValueList/valueId_ and using data specification template IEC61360 (\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3), _DataSpecificationIec61360/value_ shall be set.]
 
 :aasc3a004: pass:q[[underline]#Constraint AASc-3a-004:# For a _ConceptDescription_ with _category_ _PROPERTY_ or _VALUE_ using data specification template IEC61360 (`\http://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3`), _DataSpecificationIec61360/dataType_ is mandatory and shall be one of _DATE, STRING, STRING_TRANSLATABLE, INTEGER_MEASURE, INTEGER_COUNT, INTEGER_CURRENCY, REAL_MEASURE, REAL_COUNT, REAL_CURRENCY, BOOLEAN, RATIONAL, RATIONAL_MEASURE, TIME, TIMESTAMP_.]
 

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/introduction.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/introduction.adoc
@@ -28,10 +28,10 @@ image::image2.jpeg[align=center]
 
 File exchange (1) is described in Part 5 of this document series (IDTA-01005).
 
-The API (2) is specified in Part 2 of the document series "Specification of the Asset Administration Shell" (IDTA-01002) link:bibliography.adoc#bib14[[14\]].
+The API (2) is specified in Part 2 of the document series "Specification of the Asset Administration Shell" (IDTA-01002) xref:bibliography.adoc#bib14[[14\]].
 It also includes access to concept descriptions using the data specifications as specified in this document.
 
-The I4.0 language (3) is based on the information metamodel specified in Part 1 and 3 link:bibliography.adoc#bib23[[23\]].
+The I4.0 language (3) is based on the information metamodel specified in Part 1 and 3 xref:bibliography.adoc#bib23[[23\]].
 
 Part 3 is not a single document.
 Instead, it is an own series of documents, each featuring a specific use case that is supported by the specified data specification templates.
@@ -46,9 +46,9 @@ The known data dictionaries ECLASS and IEC CDD are based on this standard.
 The data specification templates specified in this document make it possible to directly use concept descriptions as standardized in these data dictionaries.
 Additionally, concept descriptions, which do not (yet) exist in these data dictionaries, can be defined using the same schema.
 
-For guidance how to use ECLASS concept definitions in combination with the Asset Administration Shell including this data specification template see link:bibliography.adoc#bib28[[28\]].
+For guidance how to use ECLASS concept definitions in combination with the Asset Administration Shell including this data specification template see xref:bibliography.adoc#bib28[[28\]].
 
-Concept descriptions, whether defined externally in existing data dictionaries or internally as part of the Asset Administration Shell environment, are the foundation for defining submodel templates link:bibliography.adoc#bib24[[24\]] link:bibliography.adoc#bib16[[16\]].
+Concept descriptions, whether defined externally in existing data dictionaries or internally as part of the Asset Administration Shell environment, are the foundation for defining submodel templates xref:bibliography.adoc#bib24[[24\]] xref:bibliography.adoc#bib16[[16\]].
 
 IEC 61360-1:2017 is largely compliant to IEC 61360-2:2012 and ISO 13584-42:2010.
 

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/preamble.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/preamble.adoc
@@ -70,7 +70,7 @@ xref:specification.adoc#category-of-concept-descriptions[Category of Concept Des
 The constraints as defined in xref:specification.adoc#cross-constraints-and-invariants-for-predefined-data-specifications-normative[Cross-Constraints and Invariants for Predefined Data Specifications (normative)] also mainly refer to the rules on how these categories should be applied.
 
 ====
-Note: since categories are deprecated since V3.0, xref:specification.adoc#category-of-concept-descriptions[Category of Concept Descriptions] can also be skipped.
+Note: since categories are deprecated since V3.0, Clause xref:specification.adoc#category-of-concept-descriptions[Category of Concept Descriptions] can also be skipped.
 ====
 
 xref:specification.adoc#primitive-and-simple-data-types-normative[Primitive and Simple Data Types (normative)] specifies the data types used in the data specification.
@@ -86,14 +86,5 @@ Metamodel changes compared to previous versions are described in xref:changelog.
 
 The bibliography can be found in xref:bibliography.adoc[].
 
-===  Working Principles
 
-The work is based on the following principle: keep it simple but do not simplify if it affects interoperability.
-
-The partners represented in the Industrial Digital Twin Association (IDTA), as well as in the Plattform Industrie 4.0 and associations such as ZVEI, VDMA, VDI/ VDE and Bitkom, ensure that there is broad sectoral coverage of process, hybrid, and factory automation and in terms of integrating information technology (IT) and operational technology (OT).
-
-Design alternatives were intensively discussed within the working group.
-An extensive feedback process of this document series is additionally performed within the working groups of Plattform Industrie 4.0 and IDTA.
-
-Guiding principle for the specification was to provide detailed information, which can be easily implemented also by small and medium-sized enterprises.
 

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/preamble.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/preamble.adoc
@@ -27,7 +27,7 @@ This document assumes familiarity with the concept and specification of the Asse
 The main stakeholders addressed in this document are architects and software developers aiming to implement a digital twin using the Asset Administration Shell in an interoperable way.
 Additionally, the content can also be used as input for discussions with international standardization organizations and further collaborations.
 
-Please consult the continuously updated reading guide link:bibliography.adoc#bib15[[15\]] for an overview of documents on the Asset Administration Shell.
+Please consult the continuously updated reading guide xref:bibliography.adoc#bib15[[15\]] for an overview of documents on the Asset Administration Shell.
 The reading guide gives advice on which documents should be read depending on the role of the reader.
 
 === Normative References

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/specification.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/specification.adoc
@@ -939,7 +939,7 @@ Max = true
 |===
 |*Attribute**^6^* |*ReferenceElement* |*File*footnote:[Template only used until explicit template is available for defining the corresponding types of elements.] |*Blob^9^* |*Capability^9^* |*RelationshipElement^9^* |*AnnotatedRelationshipElement^9^*
 h|Category of Concept Description h|REFERENCE h|DOCUMENT h|DOCUMENT h|CAPABILITY h|RELATIONSHIP h|RELATIONSHIP
-|*Category of SubmodelElement* |*--* |*--* |*--* |*--* |*--* |*--*
+h|*Category of SubmodelElement* |*--* |*--* |*--* |*--* |*--* |*--*
 |preferredName^7^ |m |m |m |m |m |m
 |shortName |(m) |(m) |(m) |(m) |(m) |(m)
 |unit |-- |-- |-- |-- |-- |--
@@ -963,7 +963,7 @@ h|Category of Concept Description h|REFERENCE h|DOCUMENT h|DOCUMENT h|CAPABILITY
 |===
 |*Attribute* |*SubmodelElementList^9^* |*SubmodelElementCollection^9^* |*Operation^9^* |*EventElement^9^* |*Entity^9^*
 h|Category of Concept Description h|COLLECTION h|ENTITY h|FUNCTION h|EVENT h|ENTITY
-|*Category of SubmodelElement* |*--* |*--* |*--* |*--* |*--*
+h|*Category of SubmodelElement* |*--* |*--* |*--* |*--* |*--*
 |preferredName^7^ |m |m |m |m |m
 |shortName |(m) |(m) |(m) |(m) |(m)
 |unit |-- |-- |-- |-- |--
@@ -987,7 +987,7 @@ h|Category of Concept Description h|COLLECTION h|ENTITY h|FUNCTION h|EVENT h|ENT
 |===
 |*Attribute* |*Submodel^9^* |*Qualifier^9^* |*SpecificAssetId*
 h|Category of Concept Description h|APPLICATION_CLASS h|QUALIFIER_TYPE h|PROPERTY
-|*Category of Element* |*--* |*--* |*--*
+h|*Category of Element* |*--* |*--* |*--*
 |preferredName |m |m |m
 |shortName |(m) |(m) |(m)
 |unit |-- |-- |

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/specification.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/specification.adoc
@@ -567,7 +567,7 @@ Values containing string with any sequence of characters, using the syntax of HT
 
 
 ====
-Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], specific STRING_TYPE, the HTML5_TYPE.
+Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], specific STRING_TYPE, the HTML5_TYPE
 ====
 
 
@@ -683,7 +683,7 @@ A set of value reference pairs
 
 
 ====
-Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], value_list/enumerated_list_of_terms.
+Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], value_list/enumerated_list_of_terms
 ====
 
 
@@ -713,7 +713,7 @@ h|Explanation h|Type h|Card
 a| a value
 
 ====
-Note: if the _valueId_ is defined as well, then the value needs to be consistent with referenced concept definition of the value in _valueId_. 
+Note: if the _valueId_ is defined as well, then the value needs to be consistent with referenced concept definition of the value in _valueId_
  
 ====
  |xref:ValueTypeIec61360[ValueTypeIec61360] |1
@@ -748,10 +748,10 @@ Note: ECLASS also proposes a mapping of IEC 61360 data types to XSD data types: 
 [width="100%",cols="31%,30%,39%",options="header",]
 |===
 h|Data Type IEC 61360 
-h|xsd Value Typefootnote:[_Property/valueType_, _Range/valueType,_ etc. are each of type _DataTypeDefXsd._
+h|xsd Value Typefootnote:[_Property/valueType_, _Range/valueType,_ etc. are each of type _DataTypeDefXsd_
 
 Note: for submodel elements like _Blob_ and _File_ or _MultiLanguageProperty and ReferenceElement,_ there is no explicitly defined _valueType_ attribute 
-because the data type is implicitly defined and fix (_BlobType_, _PathType_ or _MultiLanguageTextType, Reference_).
+because the data type is implicitly defined and fix (_BlobType_, _PathType_ or _MultiLanguageTextType, Reference_)
 
 ]
 
@@ -770,7 +770,7 @@ _Mapped to MultiLanguageProperty, i.e. type MultiLanguageText_
 
 
 ====
-Note: for details, please see Part 1 of the document series "Specification of the Asset Administration Shell".
+Note: for details, please see Part 1 of the document series "Specification of the Asset Administration Shell"
 ====
 
 
@@ -827,7 +827,7 @@ xs:string _or mapped to ReferenceElement_
 
 
 ====
-Note: for details, please see Part 1 of the document series "Specification of the Asset Administration Shell".
+Note: for details, please see Part 1 of the document series "Specification of the Asset Administration Shell"
 ====
 
 
@@ -849,7 +849,7 @@ _Mapped to submodel element File, i.e. type PathType_
 
 
 ====
-Note: for details, please see Part 1 of the document series "Specification of the Asset Administration Shell".
+Note: for details, please see Part 1 of the document series "Specification of the Asset Administration Shell"
 ====
 
 
@@ -859,7 +859,7 @@ _Mapped to submodel element Blob, i.e. type BlobType_
 
 
 ====
-Note: for details, please see Part 1 of the document series "Specification of the Asset Administration Shell".
+Note: for details, please see Part 1 of the document series "Specification of the Asset Administration Shell"
 ====
 
 
@@ -869,7 +869,7 @@ _Mapped to submodel element Blob, i.e. type BlobType_
 
 
 ====
-Note: for details, please see Part 1 of the document series "Specification of the Asset Administration Shell".
+Note: for details, please see Part 1 of the document series "Specification of the Asset Administration Shell"
 ====
 
 
@@ -891,7 +891,7 @@ For the meaning of the content attributes of the IEC 61360 data specification te
 
 The data specification template can be used to describe both properties and values.
 
-See xref:introduction.adoc#image-rel-metamodel-iec61360[Overview Relationship Metamodel Part 1 & Data Specifications IEC 61360] on how data specification templates are related to concept descriptions. <<image-categories-cds>> lists all categories used for concept descriptionsfootnote:[Note: although the possible categories are listed as enumeration, no enumeration has been defined for Referable/category.].
+See xref:introduction.adoc#image-rel-metamodel-iec61360[Overview Relationship Metamodel Part 1 & Data Specifications IEC 61360] on how data specification templates are related to concept descriptions. <<image-categories-cds>> lists all categories used for concept descriptionsfootnote:[Note: although the possible categories are listed as enumeration, no enumeration has been defined for Referable/category].
 
 The following tables recommend using specific categories to distinguish which kind of concept is described.
 They also give advice on which attributes need to be filled for which category of concept description.
@@ -1015,7 +1015,7 @@ This clause documents constraints in the context of the predefined data specific
 https://sunye.github.io/ocl/[A class invariant is a constraint that must be true for all instances of a class at any time.]
 
 ====
-Note: these constraints include elements of Part 1 Metamodel, IDTA-01001.
+Note: these constraints include elements of Part 1 Metamodel, IDTA-01001
 ====
 
 {empty}
@@ -1025,25 +1025,25 @@ Note: these constraints include elements of Part 1 Metamodel, IDTA-01001.
 {aasc3a004}
 
 ====
-Note: categories are deprecated since V3.0 of Part 1 of the document series "Specification of the Asset Administration Shell".
+Note: categories are deprecated since V3.0 of Part 1 of the document series "Specification of the Asset Administration Shell"
 ====
 
 {aasc3a005}
 
 ====
-Note: categories are deprecated since V3.0 of Part 1 of the document series "Specification of the Asset Administration Shell".
+Note: categories are deprecated since V3.0 of Part 1 of the document series "Specification of the Asset Administration Shell"
 ====
 
 {aasc3a006}
 
 ====
-Note: categories are deprecated since V3.0 of Part 1 of the document series "Specification of the Asset Administration Shell".
+Note: categories are deprecated since V3.0 of Part 1 of the document series "Specification of the Asset Administration Shell"
 ====
 
 {aasc3a007}
 
 ====
-Note: categories are deprecated since V3.0 of Part 1 of the document series "Asset Administration Shell Specification".
+Note: categories are deprecated since V3.0 of Part 1 of the document series "Asset Administration Shell Specification"
 ====
 
 {aasc3a008}
@@ -1105,13 +1105,13 @@ _Array of elements of type langString_
 
 
 ====
-Note 1: langString is a RDF data type.
+Note 1: langString is a RDF data type
 ====
 
 
 
 ====
-Note 2: a langString is a string value tagged with a language code.
+Note 2: a langString is a string value tagged with a language code
 ====
 
 
@@ -1119,45 +1119,39 @@ The realization of a langString depends on the serialization rules for a technol
 
 
 ====
-Note: as defined in Part 1 Metamodel, IDTA-01001.
+Note: as defined in Part 1 Metamodel, IDTA-01001
 ====
 
 
 a|
 In xml:
 
+[source,xml]
+----
 <aas:langString lang="EN">This is a multi-language value in English</aas:langString>
-
-<aas:langString lang="DE"> Das ist ein Multi-Language-Wert in Deutsch </aas:langString>
+<aas:langString lang="DE">Das ist ein Multi-Language-Wert in Deutsch</aas:langString>
+----
 
 In rdf:
-
+[source,rdf]
+----
 "This is a multi-language value in English"@en ;
-
 "Das ist ein Multi-Language-Wert in Deutsch"@de
+----
 
 In JSON:
 
 [source,json,linenums]
 ----
 "description": [
-
-  {
-
-      "language":"en", 
-
-         "text": "This is a multi-language value in English."
-
-  },
-
-  {
-
-"language":"de",
-
-"text": "Das ist ein Multi-Language-Wert in Deutsch." 
-
-   }
-
+   {
+     "language":"en",
+     "text": "This is a multi-language value in English."
+   },
+   {
+     "language":"de",
+     "text": "Das ist ein Multi-Language-Wert in Deutsch."
+   }
 ]
 ----
 

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/specification.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/specification.adoc
@@ -1173,7 +1173,7 @@ Note 2: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]
 
 
 a|
-"max. rotation speed"@EN
+"max. rotation speed"@en
 
 ====
 Note: see xref:introduction.adoc#image-property-eclass[Figure 2. Example Property from ECLASS]

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/specification.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/specification.adoc
@@ -99,7 +99,7 @@ h|ID: 3+| `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationI
 h|Explanation h|Type h|Card.
 
 
-.2+e|[[data-specification-content-preferred-name]]preferredName 3+| \https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataSpecificationIec61360/preferredName`
+.2+e|[[data-specification-content-preferred-name]]preferredName 3+| `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataSpecificationIec61360/preferredName`
 
 a|
 Preferred name in different languages
@@ -117,7 +117,7 @@ Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]],
 
 
 
-.2+e|shortName 3+| \https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataSpecificationIec61360/shortName`
+.2+e|shortName 3+| `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataSpecificationIec61360/shortName`
 a|
 Short name
 
@@ -129,7 +129,7 @@ Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]],
 
 |xref:ShortNameTypeIec61360[ShortNameTypeIec61360] |0..1
 
-.2+e|unit 3+| \https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataSpecificationIec61360/unit`
+.2+e|unit 3+| `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataSpecificationIec61360/unit`
 a|
 Unit in case of a quantitative property
 
@@ -147,7 +147,7 @@ Note 2: only the primary unit is supported.
 
 |string |0..1
 
-.2+e|unitId 3+| \https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataSpecificationIec61360/unitId`
+.2+e|unitId 3+| `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataSpecificationIec61360/unitId`
 a|
 Unique unit ID
 
@@ -167,7 +167,7 @@ Note 2: it is recommended to use an external reference ID.
 
 |Reference |0..1
 
-.2+e|sourceOfDefinition 3+| \https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataSpecificationIec61360/sourceOfDefinition`
+.2+e|sourceOfDefinition 3+| `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataSpecificationIec61360/sourceOfDefinition`
 a|
 Source of definition
 
@@ -179,7 +179,7 @@ Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]],
 
 |string |0..1
 
-.2+e|symbol 3+| \https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataSpecificationIec61360/symbol`
+.2+e|symbol 3+| `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataSpecificationIec61360/symbol`
 a|
 Symbol
 
@@ -192,7 +192,7 @@ Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]],
 
 |string |0..1
 
-.2+e|dataType 3+| \https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataSpecificationIec61360/dataType`
+.2+e|dataType 3+| `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataSpecificationIec61360/dataType`
 a|
 Data Type
 
@@ -204,7 +204,7 @@ Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]],
 
 |xref:DataTypeIec61360[DataTypeIec61360] |0..1
 
-.2+e|definition 3+| \https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataSpecificationIec61360/definition`
+.2+e|definition 3+| `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataSpecificationIec61360/definition`
 a|
 Definition in different languages
 
@@ -216,7 +216,7 @@ Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]],
 
 |xref:DefinitionTypeIec61360[DefinitionTypeIec61360] |0..1
 
-.2+e|valueFormat 3+| \https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataSpecificationIec61360/valueFormat`
+.2+e|valueFormat 3+| `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataSpecificationIec61360/valueFormat`
 a|
 Value Format
 
@@ -228,7 +228,7 @@ Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]],
 
 |xref:ValueFormatTypeIec61360[ValueFormatTypeIec61360] |0..1
 
-.2+e|valueList 3+| \https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataSpecificationIec61360/valueList`
+.2+e|valueList 3+| `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataSpecificationIec61360/valueList`
 a|
 Enumerated list of allowed values
 
@@ -246,7 +246,7 @@ Note 2: for ease of usage, the value list is modelled as value/valueId list in t
 
 |xref:ValueList[ValueList] |0..1
 
-.2+e|value  3+| \https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataSpecificationIec61360/value`
+.2+e|value  3+| `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataSpecificationIec61360/value`
 a|
 Value (typically within a value list)
 
@@ -258,7 +258,7 @@ Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]],
 
 |xref:ValueTypeIec61360[ValueTypeIec61360] |0..1
 
-.2+e|levelType  3+| \https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataSpecificationIec61360/levelType`
+.2+e|levelType  3+| `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataSpecificationIec61360/levelType`
  a|
 Value represented by up to four variants of a numeric value in a specific role: MIN, NOM, TYP and MAX.
 

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/specification.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/specification.adoc
@@ -141,7 +141,7 @@ Note 1: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]
 
 
 ====
-Note 2: only the primary unit is supported.
+Note 2: only the primary unit is supported
 ====
 
 
@@ -156,12 +156,6 @@ Unit and unitId need to be consistent if both attributes are set
 
 ====
 Note 1: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], unit_of_measure
-====
-
-
-
-====
-Note 2: it is recommended to use an external reference ID.
 ====
 
 
@@ -234,13 +228,13 @@ Enumerated list of allowed values
 
 
 ====
-Note 1: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], enumerated_list_of_terms.
+Note 1: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], enumerated_list_of_terms
 ====
 
 
 
 ====
-Note 2: for ease of usage, the value list is modelled as value/valueId list in this data specification template.
+Note 2: for ease of usage, the value list is modelled as value/valueId list in this data specification template
 ====
 
 
@@ -317,7 +311,7 @@ h|ID: | `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec
 .2+h|Literal h| ID
 h|Explanation
 
-.2+e|DATE | `\https://admin-shell.io/aas/3/1/DataTypeIec61360/DATE`
+.2+e|DATE | `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataTypeIec61360/DATE`
 a|
 values containing a calendar date, conformant to ISO 8601:2004
 
@@ -325,19 +319,19 @@ Format yyyy-mm-dd
 
 
 ====
-Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], specific STRING_TYPE, the DATE_TYPE.
+Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], specific STRING_TYPE, the DATE_TYPE
 ====
 
 
 Example from IEC 61360-1:2017: "1999-05-31" is the DATE representation of: "31 May 1999".
 
-.2+e|STRING | `\https://admin-shell.io/aas/3/1/DataTypeIec61360/STRING`
+.2+e|STRING | `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataTypeIec61360/STRING`
 a|
 values consisting of a sequence of characters, which cannot be translated into other languages
 
 
 ====
-Note 1: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], specific STRING_TYPE, the NON_TRANSLATABLE_STRING_TYPE.
+Note 1: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]], specific STRING_TYPE, the NON_TRANSLATABLE_STRING_TYPE
 ====
 
 
@@ -348,7 +342,7 @@ It is requested to use the more specific data types in the AAS, if applicablefoo
 ====
 
 
-.2+e|STRING_TRANSLATABLE |`\https://admin-shell.io/aas/3/1/DataTypeIec61360/STRING_TRANSLATABLE`
+.2+e|STRING_TRANSLATABLE |`\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataTypeIec61360/STRING_TRANSLATABLE`
 a|
 values containing string, but which shall be represented as different strings in different languages
 
@@ -358,7 +352,7 @@ Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]],
 ====
 
 
-.2+e|INTEGER_MEASURE | `\https://admin-shell.io/aas/3/1/DataTypeIec61360/INTEGER_MEASURE`
+.2+e|INTEGER_MEASURE | `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataTypeIec61360/INTEGER_MEASURE`
 a|
 values containing values that are a measure of the type INTEGER.
 In addition, such a value comes with a physical unit.
@@ -369,7 +363,7 @@ Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]],
 ====
 
 
-.2+e|INTEGER_COUNT | `\https://admin-shell.io/aas/3/1/DataTypeIec61360/INTEGER_COUNT`
+.2+e|INTEGER_COUNT | `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataTypeIec61360/INTEGER_COUNT`
 a|
 values containing values of the type INTEGER, but which are no currencies or measures
 
@@ -386,7 +380,7 @@ Note 2: it is requested to use the more specific data types in the AAS, if appli
 ====
 
 
-.2+e|INTEGER_CURRENCY | `\https://admin-shell.io/aas/3/1/DataTypeIec61360/INTEGER_CURRENCY`
+.2+e|INTEGER_CURRENCY | `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataTypeIec61360/INTEGER_CURRENCY`
 a|
 values containing values of the type INTEGER, which are currencies
 
@@ -396,7 +390,7 @@ Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]],
 ====
 
 
-.2+e|REAL_MEASURE | `\https://admin-shell.io/aas/3/1/DataTypeIec61360/REAL_MEASURE`
+.2+e|REAL_MEASURE | `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataTypeIec61360/REAL_MEASURE`
 a|
 values containing values that are measures of the type REAL
 
@@ -408,7 +402,7 @@ Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]],
 ====
 
 
-.2+e|REAL_COUNT | `\https://admin-shell.io/aas/3/1/DataTypeIec61360/REAL_COUNT`
+.2+e|REAL_COUNT | `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataTypeIec61360/REAL_COUNT`
 a|
 values containing numbers that can be written as a terminating or non-terminating decimal; i.e. a rational or irrational number, which is neither a currency nor a measures
 
@@ -425,7 +419,7 @@ Note 2: it is requested to use the more specific data types in the AAS, if appli
 ====
 
 
-.2+e|REAL_CURRENCY | `\https://admin-shell.io/aas/3/1/DataTypeIec61360/REAL_CURRENCY`
+.2+e|REAL_CURRENCY | `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataTypeIec61360/REAL_CURRENCY`
 a|
 values containing values of the type REAL, which are currencies
 
@@ -435,7 +429,7 @@ Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]],
 ====
 
 
-.2+e|BOOLEAN | `\https://admin-shell.io/aas/3/1/DataTypeIec61360/BOOLEAN`
+.2+e|BOOLEAN | `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataTypeIec61360/BOOLEAN`
 a|
 values representing truth of logic or Boolean algebra (TRUE, FALSE)
 
@@ -452,7 +446,7 @@ In the AAS, the values are TRUE (for "Yes") and FALSE (for "No").
 ====
 
 
-.2+e|IRI | `\https://admin-shell.io/aas/3/1/DataTypeIec61360/IRI`
+.2+e|IRI | `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataTypeIec61360/IRI`
 a|
 values containing values of the type STRING conformant to https://datatracker.ietf.org/doc/html/rfc3987[Rfc 3987]
 
@@ -470,7 +464,7 @@ If the IRI represents an address to a file, FILE shall be used.
 ====
 
 
-.2+e|IRDI | `\https://admin-shell.io/aas/3/1/DataTypeIec61360/IRDI`
+.2+e|IRDI | `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataTypeIec61360/IRDI`
 a|
 values conforming to ISO/IEC 11179 series global identifier sequences
 
@@ -500,7 +494,7 @@ The identifier shall fulfil the requirements specified in ISO/TS 29002-5 for an 
 ====
 
 
-.2+e|RATIONAL | `\https://admin-shell.io/aas/3/1/DataTypeIec61360/RATIONAL`
+.2+e|RATIONAL | `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataTypeIec61360/RATIONAL`
 a|
 Values containing values of the type RATIONAL, which are no measures
 
@@ -518,7 +512,7 @@ Note 2: it is requested to use the more specific data types in the AAS, if appli
 ====
 
 
-.2+e|RATIONAL_MEASURE | `\https://admin-shell.io/aas/3/1/DataTypeIec61360/RATIONAL_MEASURE`
+.2+e|RATIONAL_MEASURE | `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataTypeIec61360/RATIONAL_MEASURE`
 a|
 values containing values of the type RATIONAL.
 In addition, such a value comes with a physical unit.
@@ -529,7 +523,7 @@ Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]],
 ====
 
 
-.2+e|TIME | `\https://admin-shell.io/aas/3/1/DataTypeIec61360/TIME`
+.2+e|TIME | `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataTypeIec61360/TIME`
 a|
 values containing a time conformant to ISO 8601:2004 but restricted to what is allowed in the corresponding type in xml.
 
@@ -543,7 +537,7 @@ Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]],
 ====
 
 
-.2+e|TIMESTAMP | `\https://admin-shell.io/aas/3/1/DataTypeIec61360/TIMESTAMP`
+.2+e|TIMESTAMP | `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataTypeIec61360/TIMESTAMP`
 a|
 values containing a time conformant to ISO 8601:2004 but restricted to what is allowed in the corresponding type in xml.
 
@@ -555,7 +549,7 @@ Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]],
 ====
 
 
-.2+e|FILE | `\https://admin-shell.io/aas/3/1/DataTypeIec61360/FILE`
+.2+e|FILE | `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataTypeIec61360/FILE`
 a|
 values containing an address to a file.
 The values are of the type URI and can represent an absolute or relative path.
@@ -567,7 +561,7 @@ It would map to the URI_TYPE.
 ====
 
 
-.2+e|HTML | `\https://admin-shell.io/aas/3/1/DataTypeIec61360/HTML`
+.2+e|HTML | `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataTypeIec61360/HTML`
 a| 
 Values containing string with any sequence of characters, using the syntax of HTML5 (see W3C Recommendation 28:2014)
 
@@ -577,7 +571,7 @@ Note: for details, please refer to xref:preamble.adoc#IEC61360-1[[IEC61360-1\]],
 ====
 
 
-.2+e|BLOB | `\https://admin-shell.io/aas/3/1/DataTypeIec61360/BLOB`
+.2+e|BLOB | `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/DataTypeIec61360/BLOB`
 a|
 values containing the content of a file.
 Values may be binaries.
@@ -700,7 +694,7 @@ h|ID: 3+| `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationI
 h|Explanation h|Type h|Card
 
 .2+e|valueReferencePair 3+| `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/ValueList/valueReferencePair`
-a|A pair of a value together with its global unique ID. |xref:ValueReferencePair[ValueReferencePair] |1..*
+a|A pair of a value together with its global unique ID, if available. |xref:ValueReferencePair[ValueReferencePair] |1..*
 |===
 
 {empty}
@@ -708,7 +702,7 @@ a|A pair of a value together with its global unique ID. |xref:ValueReferencePair
 [width="100%",cols="24%,42%,23%,11%"]
 |===
 h|Class: 3+e|[[ValueReferencePair]]ValueReferencePair
-h|Explanation: |A value reference pair within a value list. Each value has a global unique ID defining its semantic. | |
+h|Explanation: |A value reference pair within a value list. Each value may have a global unique ID defining its semantic. | |
 h|Inherits from: |-- | |
 h|ID: 3+| `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/ValueReferencePair`
 
@@ -716,15 +710,18 @@ h|ID: 3+| `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationI
 h|Explanation h|Type h|Card
 
 .2+e|value 3+| `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/ValueReferencePair/value`
-a|the value of the referenced concept definition of the value in _valueId._ |xref:ValueTypeIec61360[ValueTypeIec61360] |1
+a| a value
+
+====
+Note: if the _valueId_ is defined as well, then the value needs to be consistent with referenced concept definition of the value in _valueId_. 
+ 
+====
+ |xref:ValueTypeIec61360[ValueTypeIec61360] |1
 .2+e|valueId 3+| `\https://admin-shell.io/DataSpecificationTemplates/DataSpecificationIec61360/3/1/ValueReferencePair/valueId`
 a|
 Global unique ID of the value
 
 
-====
-Note: it is recommended to use an external reference.
-====
 
 
 |Reference | 0..1

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/summary-and-outlook.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/summary-and-outlook.adoc
@@ -10,18 +10,18 @@ SPDX-License-Identifier: CC-BY-4.0
 
 = Summary and Outlook
 
-This document provides a metamodel for specifying data specification templates for defining concept descriptions for properties and values.
-These data specification templates are conformant to IEC 61360.
+This document provides a metamodel for specifying a data specification template for defining concept descriptions for properties and values.
+This data specification templates are conformant to IEC 61360.
 
 This document is part of the document series "Specification of the Asset Administration Shell".
 
-Additional parts of the document series cover (see link:bibliography.adoc#bib14[[14\]]):
+Additional parts of the document series cover (see xref:bibliography.adoc#bib14[[14\]]):
 
 * the information model that is the basis for file exchange and interface payload definition (IDTA-01001, Part 1),
-* interfaces and APIs for accessing the information of Asset Administration Shells (access, modify, query, and execute information and active functionality) (IDTA-01002, Part 2),
+* interfaces and APIs for accessing the information of Asset Administration Shells (IDTA-01002, Part 2),
+* security aspects including access control (IDTA-01004, part 4),
 * a file exchange format AASX (IDTA-01005, Part 5),
 
 Additional parts are in preparation:
 
-* security aspects including access control (IDTA-01004, part 4),
 * physical units as used to define the semantics of quantifiable properties in IEC 61360 (IDTA-01003-b, Part 3b).

--- a/documentation/IDTA-01003-a/modules/ROOT/pages/terms-definitions-and-abbreviations.adoc
+++ b/documentation/IDTA-01003-a/modules/ROOT/pages/terms-definitions-and-abbreviations.adoc
@@ -21,15 +21,6 @@ This glossary applies only within the context of this document.
 If available, definitions were taken from IEC 63278-1 Edition 1.0 2023-12 or IEC 61360-1 Edition 4.0 2017-07.
 ====
 
-*application*::
-
-software functional element specific to the solution of a problem in industrial-process measurement and control
-
-====
-Note 1 to entry: an application can be distributed among resources and may communicate with other applications.
-====
-
-_[SOURCE: IEC TR 62390:2005-01, 3.1.2]_
 
 *attribute*::
 
@@ -52,24 +43,6 @@ _[SOURCE: IEC 63278-1:2023, note added]_
 description of a set of objects that share the same _attributes_, _operations_, methods, relationships, and semantics
 
 _[SOURCE: IEC TR 62390:2005-01, 3.1.4]_
-
-*capability*::
-
-implementation-independent potential of an Industrie 4.0 component to achieve an effect within a domain
-
-====
-Note 1 to entry: capabilities can be orchestrated and structured hierarchically.
-====
-
-====
-Note 2 to entry: capabilities can be made executable via services.
-====
-
-====
-Note 3 to entry: the impact manifests itself in a measurable effect within the physical world.
-====
-
-_[SOURCE: Glossary Industrie 4.0, minor changes]_
 
 
 *coded value*::

--- a/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes/value-reference-pair.puml
+++ b/documentation/IDTA-01003-a/modules/ROOT/partials/diagrams/classes/value-reference-pair.puml
@@ -1,6 +1,6 @@
 @startuml
 class ValueReferencePair {
   +value: ValueTypeIec61360
-  +valueId: Reference
+  +valueId: Reference[0..1]
 }
 @enduml


### PR DESCRIPTION
* make ValueReferencePair/valueId optiona (fixes #28)
* adding semantic ID for metamodel elements
* remove clause working principles
* remove some terms in terms and definitions that are not used
*  update bibliography and correct links to bib-items
* formatting and grammer, editoral changes
* remove recommendation to use external references